### PR TITLE
feat: add loops doctor config upgrades

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,12 +164,13 @@ Key types:
 
 ### Config file
 - Default path: `.loops/config.json`
-- Top-level keys: `provider_id`, `provider_config`, `loop_config`, `inner_loop`
+- Top-level keys: `version`, `provider_id`, `provider_config`, `loop_config`, `inner_loop`
 - `inner_loop` keys: `command`, `working_dir`, `env`, `append_task_url`
 
 Config shape:
 ```ts
 type LoopsConfigFile = {
+    version: number
     provider_id: "github_projects_v2"
     provider_config: GithubProjectsV2TaskProviderConfig
     loop_config?: OuterLoopConfig
@@ -204,6 +205,8 @@ type GithubProjectsV2TaskProviderConfig = {
 ```
 
 Notes:
+- `version` tracks config schema revisions; legacy configs without `version` are treated as version `0`.
+- `loops doctor` upgrades `config.json` to the latest supported version and fills missing `loop_config` keys with defaults.
 - `provider_id` currently supports only `"github_projects_v2"`.
 - `provider_config` is validated by the provider's Pydantic model.
 - Required provider secrets are validated from environment variables before provider construction.
@@ -439,6 +442,7 @@ From any non-DONE state:
 
 - `python -m loops` is the top-level wrapper CLI.
 - `python -m loops init` initializes `.loops/` scaffolding (`jobs/`, logs, state, default config).
+- `python -m loops doctor` upgrades config schema/default values in `config.json`.
 - `python -m loops run` starts the outer loop runner.
 - `python -m loops inner-loop` runs one inner-loop execution for a run directory.
 - `python -m loops signal` enqueues a run-local signal (MVP: `NEEDS_INPUT`).

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Loops writes runtime state under `.loops/`:
 Top-level config file: `.loops/config.json`
 
 - `provider_id` (string, required): currently only `"github_projects_v2"`.
+- `version` (integer, required for latest schema): config schema version. Legacy files without this field are treated as version `0`; latest is `1`.
 - `provider_config` (object, required):
 - `provider_config.url` (string, required): GitHub Projects V2 URL, for example `https://github.com/orgs/acme/projects/7`.
 - `provider_config.status_field` (string, optional, default `"Status"`): Project field name to map task status.
@@ -112,11 +113,13 @@ Subcommands:
 - `run`: run the outer loop runner.
 - `inner-loop`: run inner loop for one run directory.
 - `signal`: enqueue a state signal for a run directory.
+- `doctor`: upgrade config schema/default keys in `config.json`.
 
 Examples:
 
 ```sh
 loops init
+loops doctor
 loops run --run-once
 loops inner-loop --run-dir .loops/jobs/2026-02-09-example-task-123
 loops signal --run-dir .loops/jobs/2026-02-09-example-task-123 --message "Need approval"
@@ -161,6 +164,23 @@ Notes:
 - `--task-url` bypasses ready-status filtering for the selected task and raises an error when the URL is missing or ambiguous in poll results.
 - `LOOPS_TASK_ID`, `LOOPS_TASK_TITLE`, `LOOPS_TASK_URL`, `LOOPS_TASK_PROVIDER`, and `LOOPS_RUN_DIR` are injected into each launched inner-loop process.
 - PR approval is detected from GitHub review decision or from allowlisted approval comments configured in `loop_config`.
+
+### `loops doctor`
+
+Upgrades `config.json` to the latest supported schema version and fills missing
+`loop_config` keys with current defaults without overwriting existing values.
+
+Options:
+
+- `--config PATH`: Config file path. Default: `.loops/config.json`.
+- `-h, --help`: Show help.
+
+Examples:
+
+```sh
+loops doctor
+loops doctor --config /path/to/config.json
+```
 
 ### `loops inner-loop`
 

--- a/loops/__main__.py
+++ b/loops/__main__.py
@@ -5,7 +5,7 @@ import sys
 from loops.cli import main
 
 
-_CLI_SUBCOMMANDS = {"init", "run", "inner-loop", "signal"}
+_CLI_SUBCOMMANDS = {"init", "run", "inner-loop", "signal", "doctor"}
 
 
 def _normalize_argv(argv: list[str]) -> list[str]:

--- a/loops/cli.py
+++ b/loops/cli.py
@@ -16,12 +16,14 @@ from loops.inner_loop import reset_run_record, run_inner_loop
 from loops.outer_loop import (
     InnerLoopCommandConfig,
     INNER_LOOP_RUNS_DIR_NAME,
+    LATEST_LOOPS_CONFIG_VERSION,
     OuterLoopConfig,
     OuterLoopRunner,
     OuterLoopState,
     build_inner_loop_launcher,
     build_provider,
     load_config,
+    upgrade_config_payload,
     write_outer_state,
 )
 from loops.providers.github_projects_v2 import GITHUB_PROJECTS_V2_PROVIDER_ID
@@ -207,6 +209,42 @@ def init_command(loops_root: Path, force: bool) -> None:
     click.echo(f"Config: {config_path}")
 
 
+@main.command("doctor")
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(".loops/config.json"),
+    show_default=True,
+    help="Path to the loops config JSON.",
+)
+def doctor_command(config_path: Path) -> None:
+    """Upgrade config.json to the latest schema version and defaults."""
+
+    resolved_path = config_path.resolve()
+    if not resolved_path.exists():
+        raise click.ClickException(f"Config does not exist: {resolved_path}")
+
+    try:
+        payload = json.loads(resolved_path.read_text())
+        upgraded_payload, changed = upgrade_config_payload(payload)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if changed:
+        resolved_path.write_text(
+            json.dumps(upgraded_payload, indent=2, sort_keys=True) + "\n"
+        )
+        click.echo(
+            f"Upgraded config to version {LATEST_LOOPS_CONFIG_VERSION}: {resolved_path}"
+        )
+        return
+
+    click.echo(
+        f"Config already up to date (version {LATEST_LOOPS_CONFIG_VERSION}): {resolved_path}"
+    )
+
+
 def _run_outer_loop(
     *,
     config_path: Path,
@@ -282,6 +320,7 @@ def _build_default_config() -> dict[str, Any]:
 
     defaults = OuterLoopConfig()
     return {
+        "version": LATEST_LOOPS_CONFIG_VERSION,
         "provider_id": GITHUB_PROJECTS_V2_PROVIDER_ID,
         "provider_config": {
             "url": "https://github.com/orgs/YOUR_ORG/projects/1",

--- a/loops/outer_loop.py
+++ b/loops/outer_loop.py
@@ -32,6 +32,7 @@ DEFAULT_POLL_INTERVAL_SECONDS = 30
 DEFAULT_PARALLEL_TASKS_LIMIT = 5
 DEFAULT_TASK_READY_STATUS = "Ready"
 INNER_LOOP_RUNS_DIR_NAME = "jobs"
+LATEST_LOOPS_CONFIG_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -108,6 +109,7 @@ class InnerLoopCommandConfig:
 class LoopsConfig:
     """Top-level Loops configuration loaded from JSON."""
 
+    version: int
     provider_id: str
     provider_config: dict[str, Any]
     loop_config: OuterLoopConfig
@@ -267,8 +269,7 @@ def load_config(path: str | Path) -> LoopsConfig:
     """Load a LoopsConfig from a JSON file."""
 
     payload = json.loads(Path(path).read_text())
-    if not isinstance(payload, dict):
-        raise TypeError("Config must be a JSON object")
+    payload, _ = upgrade_config_payload(payload)
     provider_id = payload.get("provider_id")
     if not isinstance(provider_id, str) or not provider_id:
         raise TypeError("provider_id is required and must be a string")
@@ -287,11 +288,50 @@ def load_config(path: str | Path) -> LoopsConfig:
             base_dir=base_dir,
         )
     return LoopsConfig(
+        version=_load_config_version(payload),
         provider_id=provider_id,
         provider_config=provider_config,
         loop_config=loop_config,
         inner_loop=inner_loop,
     )
+
+
+def upgrade_config_payload(payload: Any) -> tuple[dict[str, Any], bool]:
+    """Upgrade a config payload in-memory to the latest schema version."""
+
+    if not isinstance(payload, dict):
+        raise TypeError("Config must be a JSON object")
+    upgraded = dict(payload)
+    changed = False
+    version = _load_config_version(upgraded)
+
+    if version > LATEST_LOOPS_CONFIG_VERSION:
+        raise ValueError(
+            f"Unsupported config version: {version}. "
+            f"Latest supported version is {LATEST_LOOPS_CONFIG_VERSION}."
+        )
+
+    if version < LATEST_LOOPS_CONFIG_VERSION:
+        upgraded["version"] = LATEST_LOOPS_CONFIG_VERSION
+        changed = True
+
+    existing_loop_payload = upgraded.get("loop_config")
+    if existing_loop_payload is None:
+        loop_payload: dict[str, Any] = {}
+    elif isinstance(existing_loop_payload, dict):
+        loop_payload = dict(existing_loop_payload)
+    else:
+        raise TypeError("loop_config must be an object")
+
+    for key, value in _default_loop_config_payload().items():
+        if key not in loop_payload:
+            loop_payload[key] = value
+            changed = True
+
+    if existing_loop_payload != loop_payload:
+        upgraded["loop_config"] = loop_payload
+
+    return upgraded, changed
 
 
 def build_provider(config: LoopsConfig) -> TaskProvider:
@@ -453,6 +493,21 @@ def _load_outer_loop_config(payload: Any) -> OuterLoopConfig:
     )
 
 
+def _default_loop_config_payload() -> dict[str, Any]:
+    defaults = OuterLoopConfig()
+    return {
+        "poll_interval_seconds": defaults.poll_interval_seconds,
+        "parallel_tasks": defaults.parallel_tasks,
+        "parallel_tasks_limit": defaults.parallel_tasks_limit,
+        "sync_mode": defaults.sync_mode,
+        "emit_on_first_run": defaults.emit_on_first_run,
+        "force": defaults.force,
+        "task_ready_status": defaults.task_ready_status,
+        "approval_comment_usernames": list(defaults.approval_comment_usernames),
+        "approval_comment_pattern": defaults.approval_comment_pattern,
+    }
+
+
 def _validate_required_secrets(
     provider: LoopsProviderConfig,
     *,
@@ -535,6 +590,15 @@ def _load_str_list(
     ):
         raise TypeError(f"{key} must be a list of strings")
     return tuple(candidate)
+
+
+def _load_config_version(payload: dict[str, Any]) -> int:
+    value = payload.get("version", 0)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("version must be an integer")
+    if value < 0:
+        raise ValueError("version must be >= 0")
+    return value
 
 
 def _is_ready(task: Task, config: OuterLoopConfig) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,11 @@ import loops.cli as cli_module
 
 from loops.__main__ import _normalize_argv, entrypoint
 from loops.cli import main
-from loops.outer_loop import LoopsConfig, OuterLoopConfig
+from loops.outer_loop import (
+    LATEST_LOOPS_CONFIG_VERSION,
+    LoopsConfig,
+    OuterLoopConfig,
+)
 from loops.run_record import RunPR, RunRecord, Task, read_run_record, write_run_record
 
 
@@ -26,6 +30,7 @@ def test_init_creates_default_loops_structure(tmp_path: Path) -> None:
     assert (loops_root / "jobs").exists()
 
     config_payload = json.loads((loops_root / "config.json").read_text())
+    assert config_payload["version"] == LATEST_LOOPS_CONFIG_VERSION
     assert config_payload["provider_id"] == "github_projects_v2"
     assert config_payload["loop_config"]["sync_mode"] is False
     assert config_payload["loop_config"]["approval_comment_usernames"] == []
@@ -67,7 +72,7 @@ def test_init_force_overwrites_existing_config(tmp_path: Path) -> None:
 
 
 def test_normalize_argv_preserves_known_subcommands() -> None:
-    argv = ["python", "init"]
+    argv = ["python", "doctor"]
     assert _normalize_argv(argv) == argv
 
 
@@ -282,6 +287,7 @@ def test_run_outer_loop_task_url_implies_run_once_and_force(
     config_path = tmp_path / "config.json"
     config_path.write_text("{}")
     loaded = LoopsConfig(
+        version=LATEST_LOOPS_CONFIG_VERSION,
         provider_id="github_projects_v2",
         provider_config={
             "url": "https://github.com/orgs/default/projects/1",
@@ -359,3 +365,39 @@ def test_run_outer_loop_task_url_implies_run_once_and_force(
     assert captured["run_once_limit"] == 7
     assert captured["run_once_task_url"] == "https://github.com/acme/api/issues/9"
     assert "run_forever_limit" not in captured
+
+
+def test_doctor_upgrades_legacy_config(tmp_path: Path) -> None:
+    runner = CliRunner()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "provider_id": "github_projects_v2",
+                "provider_config": {"url": "https://github.com/orgs/acme/projects/7"},
+                "loop_config": {"task_ready_status": "Todo"},
+            }
+        )
+    )
+
+    result = runner.invoke(main, ["doctor", "--config", str(config_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Upgraded config to version" in result.output
+    payload = json.loads(config_path.read_text())
+    assert payload["version"] == LATEST_LOOPS_CONFIG_VERSION
+    assert payload["provider_config"]["url"] == "https://github.com/orgs/acme/projects/7"
+    assert payload["loop_config"]["task_ready_status"] == "Todo"
+    assert payload["loop_config"]["parallel_tasks"] is False
+    assert payload["loop_config"]["approval_comment_usernames"] == []
+
+
+def test_doctor_reports_when_config_is_up_to_date(tmp_path: Path) -> None:
+    runner = CliRunner()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(cli_module._build_default_config()))
+
+    result = runner.invoke(main, ["doctor", "--config", str(config_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Config already up to date" in result.output

--- a/tests/test_outer_loop.py
+++ b/tests/test_outer_loop.py
@@ -13,6 +13,7 @@ from loops.approval_config import (
 )
 from loops.outer_loop import (
     InnerLoopCommandConfig,
+    LATEST_LOOPS_CONFIG_VERSION,
     LoopsConfig,
     OuterLoopConfig,
     OuterLoopRunner,
@@ -286,6 +287,7 @@ def test_load_config_reads_sync_mode(tmp_path: Path) -> None:
 
     config = load_config(config_path)
     assert config.loop_config.sync_mode is True
+    assert config.version == LATEST_LOOPS_CONFIG_VERSION
 
 
 def test_load_config_reads_comment_approval_config(tmp_path: Path) -> None:
@@ -301,6 +303,7 @@ def test_load_config_reads_comment_approval_config(tmp_path: Path) -> None:
     config_path.write_text(json.dumps(payload))
 
     config = load_config(config_path)
+    assert config.version == LATEST_LOOPS_CONFIG_VERSION
     assert config.loop_config.approval_comment_usernames == (
         "maintainer",
         "review-bot",
@@ -338,6 +341,7 @@ def test_build_provider_accepts_alias_secret_env_var(monkeypatch) -> None:
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("GH_TOKEN", "token-from-alias")
     config = LoopsConfig(
+        version=LATEST_LOOPS_CONFIG_VERSION,
         provider_id="github_projects_v2",
         provider_config={"url": "https://github.com/orgs/acme/projects/1"},
         loop_config=OuterLoopConfig(),
@@ -353,6 +357,7 @@ def test_build_provider_rejects_missing_required_secret(monkeypatch) -> None:
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
     config = LoopsConfig(
+        version=LATEST_LOOPS_CONFIG_VERSION,
         provider_id="github_projects_v2",
         provider_config={"url": "https://github.com/orgs/acme/projects/1"},
         loop_config=OuterLoopConfig(),
@@ -366,6 +371,7 @@ def test_build_provider_rejects_missing_required_secret(monkeypatch) -> None:
 def test_build_provider_validates_provider_config(monkeypatch) -> None:
     monkeypatch.setenv("GITHUB_TOKEN", "token")
     config = LoopsConfig(
+        version=LATEST_LOOPS_CONFIG_VERSION,
         provider_id="github_projects_v2",
         provider_config={
             "url": "https://github.com/orgs/acme/projects/1",
@@ -408,6 +414,7 @@ def test_build_inner_loop_launcher_sync_mode_uses_subprocess_run(
     task = make_task("1", "Ship it")
 
     config = LoopsConfig(
+        version=LATEST_LOOPS_CONFIG_VERSION,
         provider_id="github_projects_v2",
         provider_config={"url": "https://github.com/orgs/acme/projects/1"},
         loop_config=OuterLoopConfig(
@@ -449,6 +456,19 @@ def test_build_inner_loop_launcher_sync_mode_uses_subprocess_run(
     assert env["LOOPS_TASK_ID"] == task.id
     assert "LOOPS_APPROVAL_COMMENT_USERNAMES" not in env
     assert "LOOPS_APPROVAL_COMMENT_PATTERN" not in env
+
+
+def test_load_config_preserves_explicit_version(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    payload = {
+        "version": LATEST_LOOPS_CONFIG_VERSION,
+        "provider_id": "github_projects_v2",
+        "provider_config": {},
+    }
+    config_path.write_text(json.dumps(payload))
+
+    config = load_config(config_path)
+    assert config.version == LATEST_LOOPS_CONFIG_VERSION
 
 
 def test_run_once_writes_custom_comment_approval_config(tmp_path: Path) -> None:


### PR DESCRIPTION
feat: add loops doctor config upgrades

## Context
Adds a new `loops doctor` command that upgrades `.loops/config.json` to the latest schema version and fills missing `loop_config` defaults without overwriting existing values. Also introduces config versioning in the outer-loop config model, updates init output to include version, and documents the workflow in README/DESIGN.

## Testing 
- python -m pytest tests/test_cli.py tests/test_outer_loop.py
- python -m pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `loops doctor` CLI command to automatically upgrade config.json to the latest schema and fill in missing configuration defaults without overwriting existing values
  * Introduced config versioning system to manage and validate configuration schema versions

* **Documentation**
  * Updated README and design documentation with doctor command usage, examples, and best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->