### PR TITLE
fix: mirror codex output to run log

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -256,7 +256,7 @@ Task provider (GitHub Projects V2)
 - Uses `codex exec` to execute the single prompt and records a session id for resuming.
 - Is the single writer for `[INNER_LOOP_ROOT]/run.json`.
 - Consumes model-authored signals from a run-local queue and applies validated state changes to `run.json`.
-- Writes inner-loop orchestration logs to `[INNER_LOOP_ROOT]/run.log`.
+- Writes inner-loop orchestration logs to `[INNER_LOOP_ROOT]/run.log` and appends Codex output there.
 - Streams Codex/agent output to `[INNER_LOOP_ROOT]/agent.log`.
 - Supports a manual `--reset` operation to clear orchestration/session/input fields in `run.json` while preserving task metadata and existing PR link identity.
 
@@ -474,7 +474,7 @@ Task: [task]
 
 ### Logging
 - Outer loop logs: `[LOOPS_ROOT]/oloops.log`.
-- Inner loop orchestration logs: `[INNER_LOOP_ROOT]/run.log`.
+- Inner loop orchestration logs + Codex output mirror: `[INNER_LOOP_ROOT]/run.log`.
 - Agent/Codex logs: `[INNER_LOOP_ROOT]/agent.log`.
 
 ### Metrics (optional)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ LOOPS_RUN_DIR=.loops/jobs/2026-02-09-example-task-123 CODEX_CMD="codex exec --yo
 Behavior summary:
 
 - Reads and writes `run.json` as the authoritative state file.
-- Writes inner-loop orchestration logs to `run.log`.
+- Writes inner-loop orchestration logs to `run.log` and appends Codex output there.
 - Streams Codex/agent output to `agent.log`.
 - Uses `CODEX_CMD` if set; default command is `codex exec --yolo`.
 - Polls PR state with `gh pr view` when a PR is present.

--- a/docs/flows/ref.inner-loop.md
+++ b/docs/flows/ref.inner-loop.md
@@ -189,7 +189,7 @@ function runInnerLoop(runDir: Path, opts: Options): RunRecord {
 
 - Codex turn behavior (`loops/inner_loop.py:601`):
   - Builds prompt (standard vs review-feedback path).
-  - Streams stdout/stderr into `agent.log` (`loops/inner_loop.py:539`).
+  - Streams stdout/stderr into `agent.log` and appends the same output to `run.log`.
   - Extracts session id and PR URL from output.
   - Sets `needs_user_input=true` on non-zero exits or successful turns with no PR detected.
 
@@ -267,7 +267,7 @@ Key logs and emit sites:
 - Review/merge polling failures: `loops/inner_loop.py:231`, `loops/inner_loop.py:375`.
 - Signal accepted (producer): `loops/state_signal.py:75`.
 - Signal applied/ignored (consumer): `loops/inner_loop.py:952`, `loops/inner_loop.py:956`, `loops/inner_loop.py:960`.
-- Agent streamed output destination: `agent.log` via `loops/inner_loop.py:556`.
+- Agent streamed output destination: `agent.log` (also mirrored to `run.log`).
 
 ## FAQ
 

--- a/loops/inner_loop.py
+++ b/loops/inner_loop.py
@@ -444,6 +444,7 @@ def run_inner_loop(
             if cleanup_executed_for_pr != run_record.pr.url:
                 cleanup_prompt = _build_cleanup_prompt(run_record.task.url, base_prompt)
                 output, exit_code = _run_codex(command, cleanup_prompt, agent_log)
+                append_log(run_log, output)
                 if exit_code != 0:
                     run_record = _force_needs_input(
                         run_json_path,
@@ -741,6 +742,7 @@ def _run_codex_turn(
         )
 
     output, exit_code = _run_codex(command, prompt, agent_log)
+    append_log(run_log, output)
 
     session_id = _extract_session_id(output)
     codex_session = run_record.codex_session
@@ -754,8 +756,6 @@ def _run_codex_turn(
     needs_user_input = exit_code != 0
     needs_user_input_payload = run_record.needs_user_input_payload
     if exit_code != 0:
-        if output.startswith("[loops] codex invocation failed:"):
-            append_log(run_log, output)
         append_log(run_log, f"[loops] codex exit code {exit_code}")
         needs_user_input_payload = {
             "message": "Codex exited with a non-zero status. Provide guidance.",

--- a/tests/test_inner_loop.py
+++ b/tests/test_inner_loop.py
@@ -135,6 +135,8 @@ def test_inner_loop_reaches_done_lifecycle(tmp_path, monkeypatch) -> None:
     assert result.last_state == "DONE"
     assert result.pr is not None
     assert result.pr.merged_at == "2026-02-09T00:00:02Z"
+    assert result.codex_session is not None
+    assert result.codex_session.id == "session-1"
     assert counter_path.read_text() == "2"  # RUNNING + PR_APPROVED cleanup
     run_log = (run_dir / "run.log").read_text()
     assert re.search(
@@ -142,8 +144,55 @@ def test_inner_loop_reaches_done_lifecycle(tmp_path, monkeypatch) -> None:
         run_log,
         re.MULTILINE,
     )
+    assert "Opened PR https://github.com/acme/api/pull/42" in run_log
+    assert "cleanup complete" in run_log
     assert "iteration 1 enter: state=RUNNING" in run_log
     assert "exit: next_state=DONE action=done_exit" in run_log
+
+
+def test_inner_loop_sets_needs_user_input_on_nonzero_codex_exit(
+    tmp_path, monkeypatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_run_record(run_dir)
+
+    failing_stub = tmp_path / "codex_failing_stub.py"
+    failing_stub.write_text(
+        "\n".join(
+            [
+                "import json",
+                "import sys",
+                "print(json.dumps({'session_id': 'session-failed'}))",
+                "print('codex simulated non-zero exit')",
+                "sys.exit(17)",
+                "",
+            ]
+        )
+    )
+    monkeypatch.setenv(
+        "CODEX_CMD",
+        f"{shlex.quote(sys.executable)} {shlex.quote(str(failing_stub))}",
+    )
+
+    result = run_inner_loop(
+        run_dir,
+        sleep_fn=lambda _seconds: None,
+        max_iterations=5,
+    )
+
+    assert result.last_state == "NEEDS_INPUT"
+    assert result.codex_session is not None
+    assert result.codex_session.id == "session-failed"
+    assert result.needs_user_input is True
+    assert result.needs_user_input_payload == {
+        "message": "Codex exited with a non-zero status. Provide guidance.",
+        "context": {"exit_code": 17},
+    }
+
+    run_log = (run_dir / "run.log").read_text()
+    assert "codex simulated non-zero exit" in run_log
+    assert "[loops] codex exit code 17" in run_log
 
 
 def test_inner_loop_consumes_signal_and_uses_user_response_in_prompt(


### PR DESCRIPTION
fix: mirror codex output to run log

## Context
This closes the remaining acceptance gap for issue #4 by ensuring each Codex invocation appends output to `run.log` (including PR-approved cleanup turns), while preserving `agent.log` streaming.

Closes https://github.com/kevinslin/loops/issues/4

## Testing
- `pytest tests/test_inner_loop.py -q`
- `pytest -q`

## Manual Testing
- [ ] Create a run directory with `run.json`, run `loops inner-loop --run-dir <path>`, and verify Codex output appears in `run.log`
- [ ] Simulate non-zero Codex exit and confirm `run.json` sets `needs_user_input=true` with exit code context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated logging documentation to reflect that Codex output is now appended to the main run log alongside existing orchestration logs.
  * Clarified that Codex stdout/stderr are captured in both agent-specific and main run logs.

* **Tests**
  * Added test coverage for Codex session tracking during inner-loop execution.
  * Added test validation for non-zero exit code handling and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->