### PR TITLE
fix: remove START state and standardize on RUNNING

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -362,7 +362,7 @@ The outer loop uses `outer_state.json` as a dedupe ledger to avoid re-processing
 
 | State | Description |
 |-------|-------------|
-| `START` | LLM launched with initial prompt. Session being established. |
+| `RUNNING` | LLM executing the task with the current prompt context. |
 | `NEEDS_INPUT` | LLM needs human input before continuing. |
 | `WAITING_ON_REVIEW` | PR submitted. Polling for reviewer feedback. |
 | `PR_APPROVED` | PR approved. Running merge and post-merge cleanup. |
@@ -373,7 +373,7 @@ The outer loop uses `outer_state.json` as a dedupe ledger to avoid re-processing
 - `DONE` if a PR exists and `merged_at` is set (merged).
 - `PR_APPROVED` if a PR exists, `review_status` is approved, and `needs_user_input == false`.
 - `WAITING_ON_REVIEW` if a PR exists and `review_status` is not approved.
-- `START` / `RUNNING` otherwise.
+- `RUNNING` otherwise.
 
 State derivation uses only PR status plus the single `needs_user_input` flag; `last_state` is cached in `run.json`.
 
@@ -382,8 +382,8 @@ Precedence rule: `NEEDS_INPUT` has priority over `DONE`; if `needs_user_input=tr
 #### Logic
 
 **Initial entry (no state file):**
-- LLM: start with prompt. Send signal to set S:START, payload: `{ sessionID }`.
-- Retry: resume session ID with prompt `"continue"`.
+- LLM: start with prompt tagged `<state>RUNNING</state>`.
+- Retry: resume session ID with prompt `"continue"` when a prior session is recorded.
 
 **Loop** (read `run.json`, derive state, dispatch):
 
@@ -396,13 +396,6 @@ Precedence rule: `NEEDS_INPUT` has priority over `DONE`; if `needs_user_input=tr
 ```text
                          (no state file)
                                |
-                               v
-                        +--------------+
-                        |    START     |
-                        +--------------+
-                               |
-                               | LLM sends signal S:START
-                               | payload: { sessionID }
                                v
                         +--------------+
                         |   RUNNING    |  (LLM executing task)
@@ -436,8 +429,8 @@ From any non-DONE state:
 
 | State | On crash / restart | Action |
 |-------|--------------------|--------|
-| `START` (no state file) | State file missing | Start fresh with prompt |
-| `START` (session recorded) | Resume existing session | Resume session ID with prompt `"continue"` |
+| `RUNNING` (no state file) | State file missing | Start fresh with prompt |
+| `RUNNING` (session recorded) | Resume existing session | Resume session ID with prompt `"continue"` |
 | `NEEDS_INPUT` | Still waiting | Re-enter wait; do not re-send signal |
 | `WAITING_ON_REVIEW` | Polling interrupted | Continue polling PR status |
 | `PR_APPROVED` | Merge may be partial | Re-run trigger:merge-pr (idempotent) |
@@ -475,10 +468,10 @@ Single prompt used for initial run and all resumes:
 ```text
 Use dev.do to implement the task, open a PR, wait for review, address feedback, and cleanup when approved.
 If needing input from user, use "$needs_input" skill to request user input.
-The current inner-loop state is passed via a trailing <state>...</state> tag; initial state is <state>START</state>.
+The current inner-loop state is passed via a trailing <state>...</state> tag; initial state is <state>RUNNING</state>.
 Do not merge until the state is exactly <state>PR_APPROVED</state>.
 Task: [task]
-<state>START</state>
+<state>RUNNING</state>
 ```
 
 ## 7. PR review handling

--- a/docs/specs/active/2026-02-09-manage-inner-loop-state-machine.md
+++ b/docs/specs/active/2026-02-09-manage-inner-loop-state-machine.md
@@ -50,7 +50,7 @@ When the inner loop starts and encounters an existing state file, it is resuming
 
 | State | Description |
 |-------|-------------|
-| `START` | LLM has been launched with the initial prompt. Session is being established. |
+| `RUNNING` | LLM is executing the task with the current prompt context. |
 | `NEEDS_INPUT` | LLM needs input from a human before it can continue. |
 | `WAITING_ON_REVIEW` | A PR has been submitted. Polling for reviewer feedback. |
 | `PR_APPROVED` | PR has been approved. Running merge and post-merge cleanup. |
@@ -62,7 +62,7 @@ When the inner loop starts and encounters an existing state file, it is resuming
 
 When no state file exists, this is a fresh start.
 
-- **LLM**: Start with prompt. Send signal to set **S:START**, payload: `{ sessionID }`.
+- **LLM**: Start with prompt tagged `<state>RUNNING</state>`.
 - **Retry** (crash during start): Resume session ID with prompt `"continue"`.
 
 #### Loop
@@ -96,13 +96,6 @@ The inner loop reads `run.json`, derives state, and dispatches to the matching h
                                |
                                v
                         +--------------+
-                        |    START     |
-                        +--------------+
-                               |
-                               | LLM sends signal S:START
-                               | payload: { sessionID }
-                               v
-                        +--------------+
                         |   RUNNING    |  (LLM executing task)
                         +--------------+
                           |          |
@@ -134,8 +127,8 @@ From any non-DONE state:
 
 | State | On crash / restart | Action |
 |-------|--------------------|--------|
-| `START` (no state file) | State file missing | Start fresh with prompt |
-| `START` (state file exists, session recorded) | Resume existing session | Resume session ID with prompt `"continue"` |
+| `RUNNING` (no state file) | State file missing | Start fresh with prompt |
+| `RUNNING` (state file exists, session recorded) | Resume existing session | Resume session ID with prompt `"continue"` |
 | `NEEDS_INPUT` | Still waiting for input | Re-enter wait; do not re-send signal |
 | `WAITING_ON_REVIEW` | Polling was interrupted | Continue polling PR status |
 | `PR_APPROVED` | Merge may be partial | Re-run trigger:merge-pr (idempotent) |
@@ -194,14 +187,14 @@ From any non-DONE state:
 ### Phase 3: Implement inner-loop orchestrator + handlers
 - [x] Refactor `run_inner_loop` into a persistent state loop.
 - [x] Ensure `PROMPT_TEMPLATE` includes explicit `$needs_input` instruction.
-- [x] `RUNNING` / `START`: invoke Codex, persist session/output-derived PR metadata.
+- [x] `RUNNING`: invoke Codex, persist session/output-derived PR metadata.
 - [x] `WAITING_ON_REVIEW`: poll PR status with backoff and persist changes.
 - [x] `NEEDS_INPUT`: block for user handoff, persist response, clear input flag.
 - [x] `PR_APPROVED`: run trigger:merge-pr and continue polling for merged state.
 - [x] Add guardrails (max iterations, idle poll escalation to `NEEDS_INPUT`, structured logs).
 
 ### Phase 4: Add explicit retry/crash recovery
-- [ ] Ensure START state detects existing session and resumes with `"continue"` prompt.
+- [ ] Ensure RUNNING state detects existing session and resumes with `"continue"` prompt.
 - [ ] Ensure NEEDS_INPUT retry re-enters wait without re-sending signal.
 - [ ] Ensure WAITING_ON_REVIEW retry continues polling without side effects.
 - [ ] Ensure PR_APPROVED retry re-runs trigger:merge-pr idempotently.
@@ -266,7 +259,7 @@ Result:
 - [x] `run.json` ownership model: single writer (inner loop only).
 - [x] Signal scope: `NEEDS_INPUT` only for MVP.
 - [x] Payload field name: `needs_user_input_payload`.
-- [ ] START state: explicit state vs. derived from absence of session. Current impl derives RUNNING; consider adding explicit START.
+- [x] Initial state taxonomy: standardize on `RUNNING`; no separate initial-only state.
 
 ### Clarifications Required
 - [x] Payload schema: `{ "message": string, "context"?: object }`.

--- a/loops/inner_loop.py
+++ b/loops/inner_loop.py
@@ -44,11 +44,11 @@ PROMPT_TEMPLATE = (
     "and trigger:merge-pr when the state is exactly <state>PR_APPROVED</state>.\n"
     'If needing input from user, use "$needs_input" skill to request user input.\n'
     "The current inner-loop state is passed via a trailing <state>...</state> tag; "
-    "initial state is <state>START</state>.\n"
+    "initial state is <state>RUNNING</state>.\n"
     "Do not merge until the state is exactly <state>PR_APPROVED</state>.\n"
     "Task: {task}\n"
 )
-PROMPT_STATE_START = "START"
+PROMPT_STATE_RUNNING = "RUNNING"
 PROMPT_STATE_WAITING_ON_REVIEW = "WAITING_ON_REVIEW"
 PROMPT_STATE_PR_APPROVED = "PR_APPROVED"
 SIGNAL_OFFSET_FILE = "state_signals.offset"
@@ -663,7 +663,7 @@ def _build_prompt(
     base_prompt: Optional[str],
     *,
     user_response: Optional[str] = None,
-    state: Optional[str] = PROMPT_STATE_START,
+    state: Optional[str] = PROMPT_STATE_RUNNING,
 ) -> str:
     prompt = PROMPT_TEMPLATE.format(task=task_url)
     if user_response is not None and user_response.strip():

--- a/tests/test_inner_loop.py
+++ b/tests/test_inner_loop.py
@@ -152,7 +152,7 @@ def test_inner_loop_reaches_done_lifecycle(tmp_path, monkeypatch) -> None:
     assert "iteration 1 enter: state=RUNNING" in run_log
     assert "exit: next_state=DONE action=done_exit" in run_log
     prompts = prompt_log_path.read_text()
-    assert "<state>START</state>" in prompts
+    assert "<state>RUNNING</state>" in prompts
     assert "<state>PR_APPROVED</state>" in prompts
 
 
@@ -256,7 +256,7 @@ def test_inner_loop_consumes_signal_and_uses_user_response_in_prompt(
     )
     assert "Do not merge until the state is exactly <state>PR_APPROVED</state>." in prompts
     assert "User input:\\nack: Need user decision" in prompts
-    assert "<state>START</state>" in prompts
+    assert "<state>RUNNING</state>" in prompts
 
 
 def test_inner_loop_uses_user_response_for_review_feedback_turn(


### PR DESCRIPTION
fix: remove START state and standardize on RUNNING

## Context
- remove `START` from inner-loop prompt state taxonomy
- standardize initial/default state as `RUNNING` across runtime, tests, and docs
- align `DESIGN.md` and the active inner-loop state-machine spec with runtime behavior
- closes https://github.com/kevinslin/loops/issues/23

## Testing
- python -m pytest tests/test_inner_loop.py
- python -m pytest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string/taxonomy change, but it does alter the initial `<state>` tag passed to the agent so any tooling or prompts that depended on `START` would need to follow the new `RUNNING` convention.
> 
> **Overview**
> Removes the initial-only `START` state from the inner-loop state taxonomy and standardizes the initial/default prompt state tag to `RUNNING`.
> 
> Updates the runtime prompt construction in `loops/inner_loop.py` (default `_build_prompt` state and `PROMPT_TEMPLATE` wording), adjusts `tests/test_inner_loop.py` expectations for `<state>RUNNING</state>`, and aligns `DESIGN.md` plus the active state-machine spec to match the new state naming and retry tables/diagrams.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61965bb946369b56400b159a099e87757aab4c0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design specifications and comprehensive documentation for the inner-loop state machine to reflect revised naming conventions and state flow descriptions.

* **Refactor**
  * Renamed initial state identifier throughout the implementation and test suite to align with updated state machine terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->