### PR TITLE
fix: detect trailing NEEDS_INPUT state marker in codex output

### DIFF
--- a/docs/flows/ref.inner-loop.md
+++ b/docs/flows/ref.inner-loop.md
@@ -207,7 +207,7 @@ function runInnerLoop(runDir: Path, opts: Options): RunRecord {
   - Base prompt contract explicitly forbids using the `gen-notifier` skill while running inside loops.
   - Selects invocation strategy (new session vs `resume <session_id>`) from `run_record.codex_session`.
   - Streams stdout/stderr into `agent.log` and appends the same output to `run.log`.
-  - Extracts session id, PR URL, and a trailing `<state>...</state>` marker from output (if present on the final line).
+  - Extracts session id, PR URL, and a trailing `<state>...</state>` marker from output when the final line is marker-only (legacy `</>` close tag is also accepted for compatibility).
   - Sets `needs_user_input=true` on non-zero exits, on trailing `NEEDS_INPUT` state markers, or on successful turns with no PR detected.
 
 - Review polling behavior (`loops/inner_loop.py:767`):

--- a/docs/research/2026-03-01-research-github-actions-ci-status-values.md
+++ b/docs/research/2026-03-01-research-github-actions-ci-status-values.md
@@ -1,0 +1,276 @@
+# Research Brief: GitHub Actions CI Status Values and Loops Normalization
+
+**Last Updated**: 2026-03-01
+
+**Status**: Complete
+
+**Related**:
+
+- `DESIGN.md`
+- `docs/flows/ref.inner-loop.md`
+- `loops/inner_loop.py`
+- `loops/run_record.py`
+
+* * *
+
+## Executive Summary
+
+This brief documents the different CI status vocabularies exposed by GitHub (GraphQL enums, Checks APIs, Workflow Runs APIs, and legacy Commit Status APIs) and maps them to Loops' normalized `ci_status` model (`pending | success | failure`).
+
+The key finding is that GitHub uses overlapping but non-identical status/conclusion sets across API surfaces, and Loops intentionally collapses that larger set into three values. That collapse is mostly correct for merge-gating, but it hides distinctions (for example `neutral`, `skipped`, `action_required`, and `expected`) that can matter for diagnostics or policy decisions.
+
+**Research Questions**:
+
+1. What are the authoritative CI status/conclusion values across GitHub API surfaces relevant to pull-request CI?
+
+2. Which values are GitHub Actions-only versus general checks/status values?
+
+3. How does Loops currently normalize these values, and where are the semantic gaps?
+
+* * *
+
+## Research Methodology
+
+### Approach
+
+- Queried GitHub's live GraphQL schema via introspection (`gh api graphql`) for enum values.
+- Reviewed GitHub official docs for REST Check Runs, Workflow Runs, Commit Statuses, and Status Checks behavior.
+- Traced Loops inner-loop CI parsing from PR polling (`gh pr view`) through normalization and state transitions.
+
+### Sources
+
+- GitHub GraphQL enum reference (`CheckStatusState`, `CheckConclusionState`, `CheckRunState`, `StatusState`): https://docs.github.com/en/graphql/reference/enums
+- GitHub REST checks (check runs): https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28
+- GitHub REST actions workflow runs: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28
+- GitHub REST commit statuses: https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28
+- GitHub status checks behavior doc: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks
+- Local code paths: `loops/inner_loop.py`, `loops/run_record.py`, `tests/test_inner_loop.py`
+
+* * *
+
+## Research Findings
+
+### Context Triage Gate (Temporal Ordering)
+
+| Value | Source of truth | Representation | Initialization point | Snapshot point | First consumer | Initialized before capture? |
+| --- | --- | --- | --- | --- | --- | --- |
+| PR status payload | `gh pr view --json ... statusCheckRollup` | JSON object | `loops/inner_loop.py:1744` subprocess call | parsed JSON at `loops/inner_loop.py:1770` | `_ci_status_from_rollup` at `loops/inner_loop.py:1801` | Yes |
+| `statusCheckRollup` entries | GitHub PR payload | list of status contexts/check runs | same payload | read at `loops/inner_loop.py:1469` | per-item parser in `_ci_status_from_rollup` | Yes |
+| Normalized `RunPR.ci_status` | Loops `RunPR` | `pending | success | failure` | `_ci_status_from_rollup` at `loops/inner_loop.py:1468` | persisted to `run.json` at `loops/inner_loop.py:1879` | auto-approve/state derivation | Yes |
+| Auto-approve CI gate | Loops runtime | boolean branch (`ci_status == success`) | read at `loops/inner_loop.py:546` | N/A | `_run_auto_approve_eval` gate | Yes |
+| Run-state transition gate | `derive_run_state` | conditional on `pr.ci_status` | read at `loops/run_record.py:245` | N/A | state machine routing | Yes |
+
+Ordering is valid in current flow: normalized `ci_status` is always derived before CI-dependent decisions.
+
+* * *
+
+### GitHub CI Status Taxonomy by API Surface
+
+#### GraphQL (authoritative enums)
+
+**Status**: Complete
+
+**Details**:
+
+- Live introspection (`gh api graphql`) currently returns:
+  - `CheckStatusState`: `REQUESTED`, `QUEUED`, `IN_PROGRESS`, `COMPLETED`, `WAITING`, `PENDING`
+  - `CheckConclusionState`: `ACTION_REQUIRED`, `TIMED_OUT`, `CANCELLED`, `FAILURE`, `SUCCESS`, `NEUTRAL`, `SKIPPED`, `STARTUP_FAILURE`, `STALE`
+  - `StatusState`: `EXPECTED`, `ERROR`, `FAILURE`, `PENDING`, `SUCCESS`
+  - `StatusCheckRollupContext` union: `CheckRun` or `StatusContext`
+- This confirms that PR rollups can mix check-run data and commit-status-style contexts.
+
+**Assessment**: GraphQL schema is the cleanest canonical reference for enum completeness.
+
+* * *
+
+#### REST Checks API (check run lifecycle and conclusions)
+
+**Status**: Complete
+
+**Details**:
+
+- Check run `status` includes `queued`, `in_progress`, `completed`, `waiting`, `requested`, `pending`.
+- Docs explicitly note `requested`, `waiting`, and `pending` are GitHub Actions-only statuses.
+- When completed, check run `conclusion` includes `action_required`, `cancelled`, `failure`, `neutral`, `success`, `skipped`, `stale`, `timed_out`.
+
+**Assessment**: REST checks docs match GraphQL status/conclusion families and clarify Actions-only states.
+
+* * *
+
+#### REST Workflow Runs API (mixed filter vocabulary)
+
+**Status**: Complete
+
+**Details**:
+
+- Workflow-runs `status` filter accepts both run statuses and conclusion-like values in one parameter.
+- Allowed values include `completed`, `in_progress`, `queued`, `requested`, `waiting`, `pending`, plus outcome values like `success`, `failure`, `cancelled`, `neutral`, `skipped`, `stale`, `timed_out`, `action_required`.
+- Docs also mark `waiting`, `pending`, and `requested` as GitHub Actions-only.
+
+**Assessment**: The mixed filter parameter is easy to misread; treat it as search vocabulary, not a single enum for run-state modeling.
+
+* * *
+
+#### REST Commit Statuses API (legacy external CI model)
+
+**Status**: Complete
+
+**Details**:
+
+- Commit statuses expose `error`, `failure`, `pending`, `success`.
+- Combined status rolls up to `failure`, `pending`, or `success`.
+- `StatusContext` values in GraphQL rollups align to this older model (`EXPECTED`, `ERROR`, `FAILURE`, `PENDING`, `SUCCESS`).
+
+**Assessment**: Still relevant because PR rollups can include status contexts from non-check integrations.
+
+* * *
+
+### Loops Normalization Behavior
+
+#### Current normalization logic
+
+**Status**: Complete
+
+**Details**:
+
+- Loops stores only three CI values: `pending | success | failure` (`loops/run_record.py:11`).
+- `_ci_status_from_rollup` behavior (`loops/inner_loop.py:1468`):
+  - Missing/empty rollup => `pending`.
+  - Pending-like states (`EXPECTED`, `PENDING`, `QUEUED`, `IN_PROGRESS`, `WAITING`, `REQUESTED`) => `pending`.
+  - Success-like conclusions (`SUCCESS`, `NEUTRAL`, `SKIPPED`) => `success`.
+  - Failure-like conclusions (`FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`) and `ERROR` => `failure`.
+  - Unknown non-success conclusions default to `failure`.
+- Auto-approve gate only opens when normalized status is `success` (`loops/inner_loop.py:546`, `loops/run_record.py:245`).
+
+**Assessment**: Deliberately conservative; good for safety gates, lossy for debugging and policy nuance.
+
+* * *
+
+#### Key semantic gaps introduced by normalization
+
+**Status**: Complete
+
+**Details**:
+
+- `neutral` and `skipped` are treated as `success` (consistent with GitHub's dependent-check behavior), but policy may differ for some teams.
+- `action_required` is collapsed into `failure`; this is safe for gating, but not actionably descriptive.
+- `expected` (status context waiting for report) is collapsed into `pending`; this is usually correct but can mask integration drift.
+- Unknown future statuses default to `pending` (if interpreted as active) or `failure` (if interpreted as non-success conclusion), which can produce behavior shifts after upstream API changes.
+
+**Assessment**: Current mapping favors safety and progress gating over observability precision.
+
+* * *
+
+## Comparative Analysis
+
+| Criteria | Raw GitHub values (no collapse) | Current Loops normalized model (`pending/success/failure`) | Expanded normalized model (example: + `neutral`, `blocked`, `cancelled`) |
+| --- | --- | --- | --- |
+| Fidelity to GitHub semantics | High | Low-Medium | Medium-High |
+| Simplicity for state machine gates | Low | High | Medium |
+| Backward compatibility with current Loops logic | N/A | High | Low-Medium |
+| Debuggability | High | Medium | High |
+| Risk of accidental merge on ambiguous CI | Medium | Low | Low-Medium |
+
+**Strengths/Weaknesses Summary**:
+
+- **Raw values**: Maximum detail, but complicates run-state decisions.
+- **Current Loops model**: Minimal and robust for gating; hides actionable distinctions.
+- **Expanded model**: Better diagnostics/policy controls at the cost of migration and additional logic.
+
+* * *
+
+## Best Practices
+
+1. **Document API surface explicitly**: Always state whether a value comes from check `status`, check `conclusion`, workflow filter vocabulary, or commit status context.
+
+2. **Treat Actions-only states specially**: `requested`, `waiting`, and `pending` can indicate orchestration conditions rather than failing CI.
+
+3. **Keep normalization conservative for merge gates**: Mapping unknown/non-success conclusions to failure avoids accidental promotion.
+
+4. **Persist richer raw diagnostics when possible**: Store raw rollup values in logs even if run-state uses a collapsed enum.
+
+5. **Validate enum drift periodically**: Use GraphQL introspection in CI/docs checks to detect upstream value additions.
+
+* * *
+
+## Open Research Questions
+
+1. **Should `neutral` and `skipped` remain auto-approve eligible?** This is currently treated as success; some teams may require strict `success` only.
+
+2. **Do we want a "blocked" class for `action_required` / `waiting`?** This could improve handoff messaging without merging risk.
+
+3. **Should raw rollup snapshots be persisted in `run.json`?** It would improve postmortem quality and reduce ambiguity.
+
+* * *
+
+## Recommendations
+
+### Summary
+
+Keep the current 3-value gate for safety and simplicity, but augment observability by recording raw GitHub CI states/conclusions alongside normalized status.
+
+### Recommended Approach
+
+- Preserve current `RunPR.ci_status` enum (`pending | success | failure`) for state transitions.
+- Add lightweight raw-status diagnostics (for example in logs and/or optional run metadata):
+  - observed `status` values
+  - observed `conclusion` values
+  - observed `StatusContext.state` values
+- Add explicit docs note that `neutral`/`skipped` are intentionally treated as success.
+- Add a periodic schema-check step using GraphQL introspection to detect enum drift.
+
+**Rationale**:
+
+- Avoids churn in core state machine behavior.
+- Improves operator visibility when CI appears "green" but semantics are nuanced.
+- Makes future policy changes data-driven instead of speculative.
+
+### Alternative Approaches
+
+- Expand `RunPR.ci_status` to more states now:
+  - Better precision, but requires schema migration and transition rewrites.
+- Preserve only current collapsed model with no extra diagnostics:
+  - Lowest implementation effort, but recurring ambiguity for failures and blocked states.
+
+* * *
+
+## References
+
+- GitHub GraphQL Enums: https://docs.github.com/en/graphql/reference/enums
+- GitHub Checks API (check runs): https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28
+- GitHub Workflow Runs API: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28
+- GitHub Commit Statuses API: https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28
+- About status checks: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks
+- Loops CI parsing and state gates: `loops/inner_loop.py`, `loops/run_record.py`, `tests/test_inner_loop.py`
+
+* * *
+
+## Appendices
+
+### Appendix A: Live GraphQL Introspection Snapshot (2026-03-01)
+
+```bash
+gh api graphql -f query='query { __type(name: "CheckStatusState") { enumValues { name } } }'
+# REQUESTED, QUEUED, IN_PROGRESS, COMPLETED, WAITING, PENDING
+
+gh api graphql -f query='query { __type(name: "CheckConclusionState") { enumValues { name } } }'
+# ACTION_REQUIRED, TIMED_OUT, CANCELLED, FAILURE, SUCCESS, NEUTRAL, SKIPPED, STARTUP_FAILURE, STALE
+
+gh api graphql -f query='query { __type(name: "StatusState") { enumValues { name } } }'
+# EXPECTED, ERROR, FAILURE, PENDING, SUCCESS
+```
+
+### Appendix B: Loops Mapping Table
+
+| Raw value family | Raw examples | Loops normalized |
+| --- | --- | --- |
+| Pending-like | `EXPECTED`, `PENDING`, `QUEUED`, `IN_PROGRESS`, `WAITING`, `REQUESTED` | `pending` |
+| Success-like | `SUCCESS`, `NEUTRAL`, `SKIPPED` | `success` |
+| Failure-like | `ERROR`, `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE` | `failure` |
+
+## Manual Notes 
+
+[keep this for the user to add notes. do not change between edits]
+
+## Changelog
+- 2026-03-01: Added research brief on GitHub Actions/Checks CI status values and Loops normalization behavior. (019ca6d6-fe69-71b2-afff-e68357a6a8d0)

--- a/loops/inner_loop.py
+++ b/loops/inner_loop.py
@@ -77,7 +77,7 @@ UUID_PATTERN = re.compile(
     re.IGNORECASE,
 )
 TRAILING_STATE_MARKER_PATTERN = re.compile(
-    r"<state>\s*([A-Za-z_]+)\s*</(?:state)?>",
+    r"^\s*<state>\s*([A-Za-z_]+)\s*</(?:state)?>\s*$",
     re.IGNORECASE,
 )
 STATE_MARKER_VALUES = {"RUNNING", "WAITING_ON_REVIEW", "NEEDS_INPUT", "PR_APPROVED", "DONE"}
@@ -552,8 +552,8 @@ def _handle_waiting_on_review_state(
         if run_record.pr.ci_status == "success":
             review_status = run_record.pr.review_status or "open"
             # Keep the old manual-approval behavior: if already approved, derive PR_APPROVED
-            # directly. Auto-approve evaluation is only for still-waiting review states.
-            if review_status not in {"approved", "changes_requested"}:
+            # directly. Auto-approve evaluation applies to any not-yet-approved state.
+            if review_status != "approved":
                 verdict = (
                     run_record.auto_approve.verdict
                     if run_record.auto_approve is not None
@@ -1023,7 +1023,7 @@ def _build_auto_approve_eval_prompt(
         state=None,
     )
     prompt += (
-        f"\nPR {pr_url} has review approval and green CI. "
+        f"\nPR {pr_url} is not yet review-approved and has green CI. "
         "Run $ag-judge (judge book: references/jb.coding.md) against current diff, "
         "review threads, and CI evidence. Return exactly one JSON object on one line "
         'with keys: {"verdict":"APPROVE|REJECT|ESCALATE","impact":1-5,'

--- a/tests/test_inner_loop.py
+++ b/tests/test_inner_loop.py
@@ -342,6 +342,77 @@ def test_handle_waiting_on_review_state_runs_auto_approve_once(
     assert evaluations["count"] == 1
 
 
+def test_handle_waiting_on_review_state_runs_auto_approve_for_changes_requested_without_new_feedback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    reviewed_at = "2026-02-09T00:00:01Z"
+    _write_run_record(
+        run_dir,
+        pr=RunPR(
+            url="https://github.com/acme/api/pull/42",
+            number=42,
+            repo="acme/api",
+            review_status="changes_requested",
+            merged_at=None,
+            last_checked_at="2026-02-09T00:00:00Z",
+            latest_review_submitted_at=reviewed_at,
+            review_addressed_at=reviewed_at,
+        ),
+    )
+    run_record = read_run_record(run_dir / "run.json")
+    runtime = _runtime_context(
+        run_dir,
+        auto_approve_enabled=True,
+        pr_status_fetcher=lambda pr: RunPR(
+            url=pr.url,
+            number=pr.number,
+            repo=pr.repo,
+            review_status="changes_requested",
+            ci_status="success",
+            merged_at=None,
+            last_checked_at="2026-02-09T00:00:02Z",
+            latest_review_submitted_at=reviewed_at,
+            review_addressed_at=reviewed_at,
+        ),
+    )
+    control = inner_loop_module.LoopControlState(backoff_seconds=5.0)
+    evaluations = {"count": 0}
+
+    def fake_run_auto_approve_eval(*, run_record, runtime, control):
+        evaluations["count"] += 1
+        return write_run_record(
+            runtime.run_json_path,
+            replace(
+                run_record,
+                auto_approve=RunAutoApprove(
+                    verdict="REJECT",
+                    impact=2,
+                    risk=4,
+                    size=2,
+                    judged_at="2026-02-09T00:00:03Z",
+                    summary="Too risky to auto-merge.",
+                ),
+            ),
+            auto_approve_enabled=runtime.auto_approve_enabled,
+        )
+
+    monkeypatch.setattr(inner_loop_module, "_run_auto_approve_eval", fake_run_auto_approve_eval)
+
+    result = inner_loop_module._handle_waiting_on_review_state(
+        run_record=run_record,
+        runtime=runtime,
+        control=control,
+    )
+
+    assert result.action == "auto_approve_eval"
+    assert evaluations["count"] == 1
+    assert result.run_record.auto_approve is not None
+    assert result.run_record.auto_approve.verdict == "REJECT"
+
+
 def test_handle_waiting_on_review_state_skips_auto_approve_until_ci_green(
     tmp_path: Path,
     monkeypatch,
@@ -1675,8 +1746,10 @@ def test_invoke_codex_retries_without_resume_on_resume_failure(
     [
         ("work complete\n<state>NEEDS_INPUT</state>\n", "NEEDS_INPUT"),
         ("work complete\n<state>needs_input</>\n", "NEEDS_INPUT"),
-        ("work complete\nstatus: <state>WAITING_ON_REVIEW</state>\n", "WAITING_ON_REVIEW"),
+        ("work complete\n   <state>WAITING_ON_REVIEW</state>   \n", "WAITING_ON_REVIEW"),
         ("work complete\n<state>NEEDS_INPUT</state>\nfollow up\n", None),
+        ("work complete\nstatus: <state>WAITING_ON_REVIEW</state>\n", None),
+        ("work complete\n<state>RUNNING</state> <state>NEEDS_INPUT</state>\n", None),
         ("work complete\n<state>UNKNOWN</state>\n", None),
     ],
 )


### PR DESCRIPTION
fix: detect trailing NEEDS_INPUT state marker in codex output

## Context
- Detect a trailing `<state>...</state>` marker from Codex output by checking only the final output line.
- Treat trailing `NEEDS_INPUT` as authoritative for setting `needs_user_input=true`, even when a PR already exists.
- Keep existing merge/review safety gates unchanged (no direct state override to `PR_APPROVED`/`DONE`).
- Update inner-loop flow docs to reflect the new marker handling behavior.

Closes https://github.com/kevinslin/loops/issues/36

## Testing
- `python -m pytest tests/test_inner_loop.py -k "trailing_state_marker or run_codex_turn_sets_needs_input_from_trailing_state_marker"`
- `python -m pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated inner-loop docs with improved output parsing and added a research brief on CI status normalization.

* **New Features**
  * Recognizes trailing state markers so the system can more reliably detect when user input is required or when awaiting review.

* **Tests**
  * Added comprehensive tests for trailing state parsing and for handling runs that request user input or waiting-on-review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->