### PR TITLE
fix: require posting a-review and ag-judge results to PR comments

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -550,6 +550,7 @@ Base template (always present in Codex turns):
 ```text
 Use dev.do to implement the task, open a PR, wait only for review from the a-review subagent, address feedback, and trigger:merge-pr when the state is exactly <state>PR_APPROVED</state>.
 You are running inside the loops test harness. NEVER wait for human PR review/comments inside the agent; the harness monitors review activity and will re-invoke you when feedback arrives.
+When you run a-review, always post its response to the PR comments. If there are no findings, explicitly post that no issues were found.
 NEVER use the gen-notifier skill while running inside loops.
 The current inner-loop state is passed via a trailing <state>...</state> tag; initial state is <state>RUNNING</state>.
 If you need input from user, print what you need help with and end current conversation with <state>NEEDS_INPUT</>
@@ -584,7 +585,7 @@ PR [pr_url] has new discussion comments. Review the feedback, address requested 
 3. Auto-approval evaluation prompt (inline within `WAITING_ON_REVIEW`):
 
 ```text
-PR [pr_url] is not yet review-approved and has green CI. Run $ag-judge (judge book: references/jb.coding.md) against current diff, review threads, and CI evidence, then return one verdict plus impact/risk/size scores.
+PR [pr_url] is not yet review-approved and has green CI. Run $ag-judge (judge book: references/jb.coding.md) against current diff, review threads, and CI evidence. Post the ag-judge verdict and impact/risk/size scores to the PR comments, then return one verdict plus impact/risk/size scores.
 <state>WAITING_ON_REVIEW</state>
 ```
 
@@ -596,7 +597,7 @@ State-to-prompt mapping:
 | `WAITING_ON_REVIEW` (no new feedback event) | No Codex prompt is built; inner loop only polls PR state. | N/A |
 | `WAITING_ON_REVIEW` (changes requested review) | `PR [pr_url] has changes requested. Address review feedback, update the PR, and summarize what changed.` | `<state>WAITING_ON_REVIEW</state>` |
 | `WAITING_ON_REVIEW` (new discussion comments) | `PR [pr_url] has new discussion comments. Review the feedback, address requested changes, update the PR, and summarize what changed. If there are no changes requested, summarize that and end the current turn.` | `<state>WAITING_ON_REVIEW</state>` |
-| `WAITING_ON_REVIEW` (auto-approve evaluation) | `PR [pr_url] is not yet review-approved and has green CI. Run $ag-judge (judge book: references/jb.coding.md) against current diff, review threads, and CI evidence, then return one verdict plus impact/risk/size scores.` | `<state>WAITING_ON_REVIEW</state>` |
+| `WAITING_ON_REVIEW` (auto-approve evaluation) | `PR [pr_url] is not yet review-approved and has green CI. Run $ag-judge (judge book: references/jb.coding.md) against current diff, review threads, and CI evidence. Post the ag-judge verdict and impact/risk/size scores to the PR comments, then return one verdict plus impact/risk/size scores.` | `<state>WAITING_ON_REVIEW</state>` |
 | `PR_APPROVED` | `PR is approved. Run cleanup now and report completion.` | `<state>PR_APPROVED</state>` |
 | `NEEDS_INPUT` | No Codex prompt is built while waiting. The handoff handler shows `needs_user_input_payload.message` to the user instead. | N/A |
 | `DONE` | No prompt; loop exits. | N/A |
@@ -620,6 +621,8 @@ Prompt-related configuration and runtime inputs:
 - When a review requests changes, the inner loop records `latest_review_submitted_at` (the review's `submittedAt` timestamp from GitHub) and invokes Codex to address the feedback. After Codex runs, `review_addressed_at` is set to `latest_review_submitted_at`. On subsequent polls, the loop only re-invokes Codex if `latest_review_submitted_at > review_addressed_at`, indicating a genuinely new review event. This prevents duplicate fix attempts when the reviewer has not yet re-reviewed.
 - When status is still open (no formal review decision), the inner loop uses the newest timestamp between `COMMENTED` PR review and plain PR discussion comment events as its feedback signal. It uses the same `latest_review_submitted_at > review_addressed_at` guard to decide whether to resume Codex.
 - Codex prompts must not ask the agent to wait for human review/comments inside a turn; the harness handles review polling/comment monitoring and re-invokes Codex when new feedback appears. The only in-turn waiting allowed is for the critical `a-review` subagent.
+- Prompt contract requires posting `a-review` output to PR comments when `a-review` is run, including explicit no-findings comments.
+- Prompt contract requires posting `ag-judge` verdict and impact/risk/size scores to PR comments during auto-approve evaluation turns.
 - When approval is detected (GitHub review decision or an allowlisted approval signal newer than latest `CHANGES_REQUESTED` review), the loop derives `PR_APPROVED` via the existing manual path. If `task_provider_config.allowlist` is set, review polling first filters PR comments/reviews to allowlisted actors.
 - If review is not already approved, CI is green, and `auto_approve_enabled=true` with no stored judgement on `RunRecord.auto_approve`, the loop runs `trigger:auto-approve-eval` once (`$ag-judge`, judge book fixed to `references/jb.coding.md`) and stores verdict/scores on `RunRecord`.
 - In that additional path, `auto_approve.verdict == APPROVE` allows transition to `PR_APPROVED`; `REJECT`/`ESCALATE` keep the run blocked in `WAITING_ON_REVIEW` with no auto re-run (single evaluation per conversation).

--- a/docs/flows/ref.inner-loop.md
+++ b/docs/flows/ref.inner-loop.md
@@ -205,6 +205,7 @@ function runInnerLoop(runDir: Path, opts: Options): RunRecord {
 - Codex turn behavior (`loops/inner_loop.py:601`):
   - Builds prompt (standard vs review-feedback path).
   - Base prompt contract says Codex may wait for the `a-review` subagent but must not wait for human PR comments/reviews because the outer harness performs comment monitoring and re-invokes Codex when needed.
+  - Base prompt contract requires posting `a-review` output to PR comments whenever `a-review` runs, including explicit no-findings comments.
   - Base prompt contract explicitly forbids using the `gen-notifier` skill while running inside loops.
   - Selects invocation strategy (new session vs `resume <session_id>`) from `run_record.codex_session`.
   - Streams stdout/stderr into `agent.log` and appends the same output to `run.log`.
@@ -219,6 +220,7 @@ function runInnerLoop(runDir: Path, opts: Options): RunRecord {
   - When review status remains open, chooses the newest timestamp between the latest `COMMENTED` PR review and plain PR discussion comment and uses that as the feedback signal.
   - When review is approved, the loop derives `PR_APPROVED` via the existing manual path.
   - If review is not already approved, CI is green, and `auto_approve_enabled` is true with no stored verdict, it runs one-time `trigger:auto-approve-eval` (`$ag-judge`, fixed judge book `references/jb.coding.md`) and persists verdict/scores on `RunRecord.auto_approve`.
+  - Auto-approve prompt contract requires posting `ag-judge` verdict plus impact/risk/size scores to PR comments, alongside the machine-parseable JSON response.
   - Only `auto_approve.verdict == APPROVE` allows promotion to `PR_APPROVED`; `REJECT`/`ESCALATE` remain blocked in `WAITING_ON_REVIEW` with no automatic re-run.
 
 - Approved-state merge polling behavior (`loops/inner_loop.py`):
@@ -334,6 +336,7 @@ A: Inner loop only. Signal producers append to queue; they do not mutate `run.js
 [keep this for the user to add notes. do not change between edits]
 
 ## Changelog
+- 2026-03-01: Updated prompt contract notes to require posting `a-review` output and `ag-judge` verdict/scores to PR comments. (019caaa4-f4d8-7822-a0d0-03315986d5ef)
 - 2026-03-01: Updated review-allowlist config references to `task_provider_config.allowlist` for config schema v2 alignment. (019caa8b-0807-7603-a519-4a6be2b8e53c)
 - 2026-03-01: Added provider-driven review-actor filtering (`task_provider_config.allowlist`) to inner-loop review polling semantics. (019caa52-baf6-7913-b365-3c89049a5716)
 - 2026-02-28: Removed configurable log timestamp precision; inner-loop log timestamps are local no-timezone format with fixed fractional precision. (019ca742-f800-78a3-a5f3-11d807a04164)

--- a/loops/inner_loop.py
+++ b/loops/inner_loop.py
@@ -46,6 +46,8 @@ PROMPT_TEMPLATE = (
     "a-review subagent. NEVER wait for human PR "
     "review/comments inside the agent; the harness monitors review activity and "
     "will re-invoke you when feedback arrives.\n"
+    "When you run a-review, always post its response to the PR comments. "
+    "If there are no findings, explicitly post that no issues were found.\n"
     "NEVER use the gen-notifier skill while running inside loops.\n"
     "Spawn the a-review subagent exactly once per conversation, only while state is "
     "<state>RUNNING</state>.Do not spawn a-review again in "
@@ -1027,7 +1029,8 @@ def _build_auto_approve_eval_prompt(
     prompt += (
         f"\nPR {pr_url} is not yet review-approved and has green CI. "
         "Run $ag-judge (judge book: references/jb.coding.md) against current diff, "
-        "review threads, and CI evidence. Return exactly one JSON object on one line "
+        "review threads, and CI evidence. Post the ag-judge verdict and impact/risk/size "
+        "scores to the PR comments. Return exactly one JSON object on one line "
         'with keys: {"verdict":"APPROVE|REJECT|ESCALATE","impact":1-5,'
         '"risk":1-5,"size":1-5,"summary":"..."}.\n'
     )

--- a/tests/test_inner_loop.py
+++ b/tests/test_inner_loop.py
@@ -1013,6 +1013,11 @@ def test_inner_loop_consumes_signal_and_uses_user_response_in_prompt(
         "monitors review activity and will re-invoke you when feedback arrives."
         in prompts
     )
+    assert (
+        "When you run a-review, always post its response to the PR comments. If "
+        "there are no findings, explicitly post that no issues were found."
+        in prompts
+    )
     assert "NEVER use the gen-notifier skill while running inside loops." in prompts
     assert "trigger:merge-pr when the state is exactly <state>PR_APPROVED</state>." in prompts
     assert (
@@ -1027,6 +1032,24 @@ def test_inner_loop_consumes_signal_and_uses_user_response_in_prompt(
     assert re.search(
         r"\[loops\] user input for codex turn: present=True length=\d+",
         run_log,
+    )
+
+
+def test_build_auto_approve_eval_prompt_includes_pr_comment_instruction() -> None:
+    prompt = inner_loop_module._build_auto_approve_eval_prompt(
+        "https://github.com/kevinslin/loops/issues/49",
+        None,
+        "https://github.com/acme/api/pull/42",
+    )
+
+    assert (
+        "Post the ag-judge verdict and impact/risk/size scores to the PR comments."
+        in prompt
+    )
+    assert (
+        '{"verdict":"APPROVE|REJECT|ESCALATE","impact":1-5,"risk":1-5,"size":1-5,'
+        '"summary":"..."}'
+        in prompt
     )
 
 


### PR DESCRIPTION
fix: require posting subagent outputs as PR comments

## Context
- updates inner-loop prompts so `a-review` output is always posted to PR comments, including explicit no-findings comments
- updates auto-approve prompt so `$ag-judge` verdict plus impact/risk/size scores are posted to PR comments
- syncs prompt-contract docs (`DESIGN.md` and `docs/flows/ref.inner-loop.md`) and adds prompt assertions in tests

## Testing
- `python -m pytest tests/test_inner_loop.py`
- `python -m pytest`

## Issue
- https://github.com/kevinslin/loops/issues/49
- Closes #49


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Review findings are now automatically posted to pull request comments for improved visibility
  * Auto-approval verdicts with impact, risk, and size assessments are posted to PR comments
  * Explicit "no issues found" confirmations are posted when applicable

* **Documentation**
  * Updated flow documentation to reflect new pull request comment posting requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->