### PR TITLE
fix: preserve legacy provider_config fallback keys

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -279,6 +279,7 @@ Notes:
 - `task_provider_config` is validated by the provider's Pydantic model.
 - `task_provider_config` init defaults are emitted from provider-owned canonical builders (for `github_projects_v2`, from `loops.providers.github_projects_v2`).
 - `loops doctor` also backfills missing GitHub `task_provider_config` defaults (`status_field`, `page_size`, `allowlist`) without overwriting existing values.
+- During migration, when both legacy `provider_config` and `task_provider_config` exist, legacy provider keys are used as fallback values for missing `task_provider_config` keys before default backfill.
 - `task_provider_config.filters` supports provider-side `key=value` filters for GitHub Projects V2 (`repository`, `tag`).
 - `task_provider_config.allowlist` (GitHub provider) restricts review-phase PR comment/review signals to listed usernames; non-allowlisted actors are ignored during review polling.
 - Required provider secrets are validated from environment variables before provider construction.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Notes:
 
 Upgrades `config.json` to the latest supported schema version and fills missing
 `loop_config` keys (and GitHub `task_provider_config` defaults) without overwriting existing values.
+When both legacy `provider_config` and `task_provider_config` exist, legacy keys are treated as fallback values for missing `task_provider_config` keys before default backfill.
 
 Options:
 

--- a/loops/outer_loop.py
+++ b/loops/outer_loop.py
@@ -437,6 +437,14 @@ def upgrade_config_payload(payload: Any) -> tuple[dict[str, Any], bool]:
         changed = True
         if "task_provider_config" not in upgraded:
             upgraded["task_provider_config"] = legacy_provider_config
+        elif isinstance(legacy_provider_config, dict):
+            task_provider_config = upgraded.get("task_provider_config")
+            if isinstance(task_provider_config, dict):
+                merged_provider_config = dict(legacy_provider_config)
+                merged_provider_config.update(task_provider_config)
+                if merged_provider_config != task_provider_config:
+                    upgraded["task_provider_config"] = merged_provider_config
+                    changed = True
 
     existing_loop_payload = upgraded.get("loop_config")
     if existing_loop_payload is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -513,6 +513,38 @@ def test_doctor_upgrades_legacy_config(tmp_path: Path) -> None:
     assert payload["loop_config"]["handoff_handler"] == "stdin_handler"
 
 
+def test_doctor_merges_legacy_provider_config_fallback_keys(tmp_path: Path) -> None:
+    runner = CliRunner()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "provider_id": "github_projects_v2",
+                "provider_config": {
+                    "url": "https://github.com/orgs/acme/projects/7",
+                    "allowlist": ["Maintainer"],
+                },
+                "task_provider_config": {
+                    "url": "https://github.com/orgs/acme/projects/8",
+                },
+            }
+        )
+    )
+
+    result = runner.invoke(main, ["doctor", "--config", str(config_path)])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(config_path.read_text())
+    assert "provider_config" not in payload
+    assert payload["task_provider_config"] == {
+        "allowlist": ["Maintainer"],
+        "page_size": 50,
+        "status_field": "Status",
+        "url": "https://github.com/orgs/acme/projects/8",
+    }
+
+
 def test_doctor_upgrades_versionless_legacy_config(tmp_path: Path) -> None:
     runner = CliRunner()
     config_path = tmp_path / "config.json"


### PR DESCRIPTION
fix: preserve legacy provider_config fallback keys

## Context
- Ensures config upgrades keep legacy `provider_config` keys as fallback values when `task_provider_config` already exists.
- Prevents dropping legacy `provider_config.allowlist` during migration.
- Adds regression coverage for `loops doctor` and documents the migration behavior in `README.md` and `DESIGN.md`.

## Testing
- pytest tests/test_cli.py -k doctor
- pytest tests/test_outer_loop.py -k config
- python -m pytest

## Issue
- https://github.com/kevinslin/dendron-lite/issues/51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for provider configuration upgrades.

* **Features**
  * Enhanced configuration upgrade process to merge legacy provider settings as fallback values when transitioning to the modern provider configuration format, preserving explicitly configured values while incorporating legacy settings.

* **Tests**
  * Added test coverage for legacy provider configuration migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->