### PR TITLE
refactor: centralize loops config parsing in utils/config.py

### DIFF
--- a/docs/flows/ref.force-option.md
+++ b/docs/flows/ref.force-option.md
@@ -1,0 +1,284 @@
+# Force Option Flow
+
+Last updated: 2026-03-01
+
+## Purpose / Question Answered
+
+This document explains what happens when the outer loop is run with force behavior enabled (`loops run --force` or implied force via `--task-url`).
+It answers how force changes selection semantics, dedupe behavior, and run materialization for already-seen tasks.
+
+## Entry points
+
+- `loops/cli.py:run_command`: accepts `--force/--no-force` and `--task-url`.
+- `loops/cli.py:_run_outer_loop`: resolves effective `loop_config.force` and run mode.
+- `loops/outer_loop.py:OuterLoopRunner.run_once`: applies emit/dedupe gates using `self.config.force`.
+- `loops/outer_loop.py:OuterLoopState.has_task` and `loops/outer_loop.py:OuterLoopState.record_task`: dedupe ledger read/write used by force gating.
+
+## Call path
+
+### Phase 1: CLI force resolution and config override
+
+Trigger / entry condition:
+- Operator executes `python -m loops run ...` with either explicit `--force`/`--no-force` or `--task-url`.
+
+Entrypoints:
+- `loops/cli.py:run_command`
+- `loops/cli.py:_run_outer_loop`
+
+Ordered call path:
+- CLI parses `--force` as tri-state (`True`, `False`, or `None` when omitted).
+- `_run_outer_loop` loads config and copies `config.loop_config` to `effective_loop_config`.
+- If `task_url` is set, `_run_outer_loop` sets `force_override=True` and `sync_mode=True`.
+- Else, `force_override` is the CLI `force` value (or `None`).
+- If `force_override is not None`, replace `effective_loop_config.force` with the override.
+- Build `OuterLoopRunner` using the effective loop config and call `run_once(...)` or `run_forever(...)`.
+
+State transitions / outputs:
+- Input: CLI args + persisted config (`loop_config.force` default/value).
+- Output: runtime `OuterLoopRunner.config.force` used by downstream selection logic.
+
+Branch points:
+- `task_url != None`: force is always enabled for that invocation and `run_once` is implied.
+- `force == None`: runtime uses `loop_config.force` from config file unchanged.
+- `force == False`: runtime explicitly disables force even if config has force enabled.
+
+External boundaries:
+- None identified.
+
+#### Sudocode (Phase 1: CLI force resolution and config override)
+
+```ts
+// Source: loops/cli.py
+function run_command(config_path, run_once, limit, force, task_url):
+  _run_outer_loop(config_path, run_once, limit, force, task_url)
+
+function _run_outer_loop(config_path, run_once, limit, force, task_url):
+  config = load_config(config_path)
+  effective = config.loop_config
+
+  if task_url is not null:
+    force_override = true
+    effective = replace(effective, sync_mode=true)
+  else:
+    force_override = force
+
+  if force_override is not null:
+    effective = replace(effective, force=force_override)
+
+  config = replace(config, loop_config=effective)
+  runner = OuterLoopRunner(..., config.loop_config, ...)
+  runner.run_once(...) or runner.run_forever(...)
+```
+
+### Phase 2: Ready-task selection with force-aware emit and dedupe gates
+
+Trigger / entry condition:
+- `OuterLoopRunner.run_once(...)` begins a poll cycle.
+
+Entrypoints:
+- `loops/outer_loop.py:OuterLoopRunner.run_once`
+
+Ordered call path:
+- Read `outer_state.json` and compute `first_run = !state.initialized`.
+- Poll provider tasks (`poll_limit` is unrestricted when `forced_task_url` is set).
+- Build `ready_tasks` from either:
+  - the single URL-selected task (`forced_task_url`), or
+  - status filtering via `_is_ready(task, self.config)`.
+- Compute `should_emit = emit_on_first_run || force || !first_run`.
+- For each ready task:
+  - read `already_seen = state.has_task(task)`;
+  - always update ledger via `state.record_task(task, now_iso)`;
+  - skip only if `!should_emit`;
+  - skip seen tasks only when `already_seen && !force`;
+  - otherwise append to `emit_tasks`.
+
+State transitions / outputs:
+- Input: current `OuterLoopState`, ready tasks from provider, `self.config.force`.
+- Output: `emit_tasks` that may include previously seen tasks when force is enabled.
+
+Branch points:
+- `force=true` bypasses both:
+  - first-run suppression (`emit_on_first_run=false` no longer blocks emission), and
+  - dedupe skip for seen tasks.
+- `forced_task_url` path can raise if URL is not present in current provider poll result.
+
+External boundaries:
+- Provider poll call via `TaskProvider.poll(...)`.
+
+#### Sudocode (Phase 2: Ready-task selection with force-aware emit and dedupe gates)
+
+```ts
+// Source: loops/outer_loop.py (OuterLoopRunner.run_once)
+function run_once(limit, forced_task_url):
+  state = read_outer_state(state_path)
+  first_run = !state.initialized
+  polled = provider.poll(forced_task_url ? null : limit)
+  ready = forced_task_url ? [select_by_url(polled, forced_task_url)]
+                          : filter_ready(polled, config.task_ready_status)
+
+  should_emit = config.emit_on_first_run || config.force || !first_run
+  emit = []
+  for task in ready:
+    already_seen = state.has_task(task)
+    state.record_task(task, now_iso)  // ledger updates even when not emitted
+    if !should_emit:
+      continue
+    if already_seen && !config.force:
+      continue
+    emit.push(task)
+```
+
+### Phase 3: Forced task materialization and launch
+
+Trigger / entry condition:
+- `emit_tasks` is non-empty after force-aware selection.
+
+Entrypoints:
+- `loops/outer_loop.py:OuterLoopRunner.run_once`
+- `loops/outer_loop.py:create_run_dir`
+- `loops/outer_loop.py:OuterLoopRunner._launch_tasks`
+
+Ordered call path:
+- For each emitted task:
+  - create a new run directory under `.loops/jobs/...`;
+  - log `run_once.schedule` with task key/url and run dir;
+  - write fresh `run.json` (state `RUNNING`);
+  - write run-scoped `inner_loop_approval_config.json`;
+  - ensure `run.log` and `agent.log` files exist.
+- Launch prepared tasks.
+- In `finally`, persist `outer_state.json` and append cycle summary logs.
+
+State transitions / outputs:
+- Input: `emit_tasks` selected under force-aware gates.
+- Output: one new run directory per emitted task, even for previously seen task keys.
+
+Branch points:
+- If launcher is missing and `emit_tasks` is non-empty, fail fast.
+- Launch execution mode follows `sync_mode`/parallel settings, independent of force.
+
+External boundaries:
+- Subprocess boundary when launching inner loop commands.
+
+#### Sudocode (Phase 3: Forced task materialization and launch)
+
+```ts
+// Source: loops/outer_loop.py (OuterLoopRunner.run_once, _launch_tasks)
+for task in emit:
+  run_dir = create_run_dir(task, loops_root)
+  log("run_once.schedule ... run_dir=<path>")
+  write_run_record(run_dir / "run.json", initial_running_record(task))
+  write_inner_loop_approval_config(run_dir, loop_config + provider allowlist)
+  touch(run_dir / "run.log")
+  touch(run_dir / "agent.log")
+  to_launch.push([run_dir, task])
+
+try:
+  launch_tasks(to_launch)
+finally:
+  state.initialized = true
+  state.updated_at = now_iso
+  write_outer_state(state_path, state)
+  log("ready=<n> processed=<m>")
+```
+
+## State, config, and gates
+
+### Core state values (source of truth and usage)
+
+- `effective_loop_config.force`
+  - Source: config `loop_config.force`, optionally overridden in `_run_outer_loop`.
+  - Consumed by: `OuterLoopRunner.run_once` emit/dedupe gates.
+  - Risk area: tri-state CLI override (`None` means no override) can be misread as false.
+
+- `first_run` (`not state.initialized`)
+  - Source: persisted `outer_state.json`.
+  - Consumed by: `should_emit` expression.
+  - Risk area: first-run suppression disappears when force is true.
+
+- `outer_state.tasks` dedupe ledger
+  - Source: `state.record_task(task, now_iso)` in every cycle for ready tasks.
+  - Consumed by: `state.has_task(task)` seen-check gate.
+  - Risk area: force bypasses skip logic but still updates ledger timestamps.
+
+- `emit_tasks`
+  - Source: in-memory selection output from gates.
+  - Consumed by: run-dir materialization and launcher dispatch.
+
+### Statsig (or `None identified`)
+
+None identified.
+
+### Environment Variables (or `None identified`)
+
+None identified.
+
+### Other User-Settable Inputs (or `None identified`)
+
+| Name | Type | Where Read | Effect on Flow |
+|---|---|---|---|
+| `--force/--no-force` | CLI option | `loops/cli.py:64`, applied in `loops/cli.py:_run_outer_loop` | Overrides `loop_config.force` for this invocation. |
+| `loop_config.force` | Config file field | Loaded in `loops/outer_loop.py:load_loop_config` and consumed in `OuterLoopRunner.run_once` | Enables force behavior by default when CLI does not override. |
+| `--task-url` | CLI option | `loops/cli.py:73`, consumed in `_run_outer_loop` and `OuterLoopRunner.run_once` | Implies force + sync mode and targets one specific polled task URL. |
+| `loop_config.emit_on_first_run` | Config file field | `OuterLoopRunner.run_once` | Participates in `should_emit` gate, but force overrides first-run suppression. |
+
+### Important gates / branch controls
+
+- `should_emit = emit_on_first_run || force || !first_run`: core emit gate where force bypasses first-run suppression.
+- `if already_seen && !force: continue`: dedupe gate where force bypasses seen-task skip.
+- `if forced_task_url is not None`: switches to URL targeting path and poll-limit override.
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant U as User CLI
+    participant C as "_run_outer_loop"
+    participant O as "OuterLoopRunner.run_once"
+    participant P as TaskProvider
+    participant S as "outer_state.json"
+    participant L as Inner-loop launcher
+
+    U->>C: loops run --force [--run-once|--run-forever]
+    C->>C: compute effective loop_config.force
+    C->>O: run_once(...)
+    O->>S: read state (initialized + tasks ledger)
+    O->>P: poll(...)
+    P-->>O: tasks
+    O->>O: should_emit = emit_on_first_run || force || !first_run
+    O->>O: skip seen only when !force
+    loop each emitted task
+      O->>O: create run dir + write run.json/log files
+      O->>L: launch(run_dir, task)
+    end
+    O->>S: persist updated state in finally
+```
+
+## Observability
+
+Metrics:
+- No dedicated metrics emitter; derive force effects from outer-loop logs (`ready`, `processed`, `run_once.select` fields).
+
+Logs:
+- `run_once.start ... force=<bool> ...`
+- `run_once.select should_emit=<bool> seen=<n> skipped_seen=<n> emit=<n>`
+- `run_once.schedule key=<provider:id> url=<task-url> run_dir=<path>`
+- cycle summary `ready=<n> processed=<m>`
+
+Useful debug checkpoints:
+- Confirm effective force in `run_once.start`.
+- Compare `seen` vs `skipped_seen` in `run_once.select` (with force, `skipped_seen` should remain `0`).
+- Verify new run directories are created for previously seen task keys.
+
+## Related docs
+
+- `docs/flows/ref.outer-loop.md`
+- `docs/flows/ref.inner-loop.md`
+- `DESIGN.md`
+- `docs/specs/active/2026-02-05-implement-outer-loop-runner.md`
+
+## Manual Notes 
+
+[keep this for the user to add notes. do not change between edits]
+
+## Changelog
+- 2026-03-01: Created force-option flow doc for outer-loop `--force` behavior, including CLI override resolution, dedupe bypass semantics, and run materialization effects. (019caa54-4d1b-7712-9f8c-de8271aa0e30)

--- a/loops/outer_loop.py
+++ b/loops/outer_loop.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import shlex
 import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -18,28 +17,26 @@ from urllib.parse import urlsplit, urlunsplit
 from pydantic import ValidationError
 
 from loops.approval_config import (
-    DEFAULT_APPROVAL_COMMENT_PATTERN,
     build_inner_loop_approval_config,
     normalize_approval_usernames,
     write_inner_loop_approval_config,
 )
-from loops.handoff_handlers import (
-    DEFAULT_HANDOFF_HANDLER,
-    validate_handoff_handler_name,
-    validate_handoff_handler_provider_compatibility,
-)
 from loops.logging_utils import STREAM_LOGS_STDOUT_ENV, format_log_timestamp
 from loops.provider_types import LoopsProviderConfig, SecretRequirement
-from loops.providers.github_projects_v2 import (
-    GITHUB_PROJECTS_V2_PROVIDER_ID,
-    build_default_provider_config_payload,
-)
 from loops.providers.registry import get_provider_definition
 from loops.run_record import RunRecord, Task, write_run_record
 from loops.task_provider import TaskProvider
+from loops.utils.config import (
+    InnerLoopCommandConfig,
+    LATEST_LOOPS_CONFIG_VERSION,
+    LoopsConfig,
+    OuterLoopConfig,
+    build_default_loop_config_payload,
+    load_config,
+    upgrade_config_payload,
+)
 
 INNER_LOOP_RUNS_DIR_NAME = "jobs"
-LATEST_LOOPS_CONFIG_VERSION = 2
 
 
 class SyncModeInterruptedError(KeyboardInterrupt):
@@ -48,89 +45,6 @@ class SyncModeInterruptedError(KeyboardInterrupt):
     def __init__(self, *, run_dir: Path) -> None:
         super().__init__()
         self.run_dir = run_dir
-
-
-@dataclass(frozen=True)
-class OuterLoopConfig:
-    """Configuration for the outer loop polling and dispatch behavior."""
-
-    poll_interval_seconds: int = 30
-    parallel_tasks: bool = False
-    parallel_tasks_limit: int = 5
-    sync_mode: bool = False
-    emit_on_first_run: bool = False
-    force: bool = False
-    task_ready_status: str = "Ready"
-    approval_comment_usernames: tuple[str, ...] = ()
-    approval_comment_pattern: str = DEFAULT_APPROVAL_COMMENT_PATTERN
-    auto_approve_enabled: bool = False
-    handoff_handler: str = DEFAULT_HANDOFF_HANDLER
-
-
-@dataclass(frozen=True)
-class InnerLoopCommandConfig:
-    """Configuration for launching inner loop commands."""
-
-    command: list[str]
-    working_dir: Optional[str] = None
-    env: Optional[dict[str, str]] = None
-    append_task_url: bool = True
-
-    @staticmethod
-    def from_dict(
-        payload: dict[str, Any],
-        *,
-        base_dir: Optional[Path] = None,
-    ) -> "InnerLoopCommandConfig":
-        """Build an InnerLoopCommandConfig from a dict payload."""
-
-        if "command" not in payload:
-            raise KeyError("inner_loop.command is required")
-        raw_command = payload["command"]
-        if isinstance(raw_command, str):
-            command = shlex.split(raw_command)
-        elif isinstance(raw_command, list) and all(
-            isinstance(item, str) for item in raw_command
-        ):
-            command = list(raw_command)
-        else:
-            raise TypeError("inner_loop.command must be a string or list of strings")
-        if not command:
-            raise ValueError("inner_loop.command cannot be empty")
-        working_dir = payload.get("working_dir")
-        if working_dir is not None and not isinstance(working_dir, str):
-            raise TypeError("inner_loop.working_dir must be a string")
-        if working_dir is not None and base_dir is not None:
-            working_path = Path(working_dir)
-            if not working_path.is_absolute():
-                working_dir = str((base_dir / working_path).resolve())
-        env = payload.get("env")
-        if env is not None:
-            if not isinstance(env, dict) or not all(
-                isinstance(key, str) and isinstance(value, str)
-                for key, value in env.items()
-            ):
-                raise TypeError("inner_loop.env must be a string-to-string map")
-        append_task_url = payload.get("append_task_url", True)
-        if not isinstance(append_task_url, bool):
-            raise TypeError("inner_loop.append_task_url must be a boolean")
-        return InnerLoopCommandConfig(
-            command=command,
-            working_dir=working_dir,
-            env=env,
-            append_task_url=append_task_url,
-        )
-
-
-@dataclass(frozen=True)
-class LoopsConfig:
-    """Top-level Loops configuration loaded from JSON."""
-
-    version: int
-    task_provider_id: str
-    task_provider_config: dict[str, Any]
-    loop_config: OuterLoopConfig
-    inner_loop: Optional[InnerLoopCommandConfig] = None
 
 
 @dataclass
@@ -372,116 +286,6 @@ class OuterLoopRunner:
                 future.result()
 
 
-def load_config(path: str | Path) -> LoopsConfig:
-    """Load a LoopsConfig from a JSON file."""
-
-    payload = json.loads(Path(path).read_text())
-    payload, _ = upgrade_config_payload(payload)
-    task_provider_id = payload.get("task_provider_id")
-    if not isinstance(task_provider_id, str) or not task_provider_id:
-        raise TypeError("task_provider_id is required and must be a string")
-    task_provider_config = payload.get("task_provider_config")
-    if not isinstance(task_provider_config, dict):
-        raise TypeError("task_provider_config must be an object")
-    loop_config = _load_outer_loop_config(payload.get("loop_config"))
-    validate_handoff_handler_provider_compatibility(
-        loop_config.handoff_handler,
-        task_provider_id,
-    )
-    inner_loop_payload = payload.get("inner_loop")
-    inner_loop = None
-    if inner_loop_payload is not None:
-        if not isinstance(inner_loop_payload, dict):
-            raise TypeError("inner_loop must be an object")
-        base_dir = Path(path).resolve().parent
-        inner_loop = InnerLoopCommandConfig.from_dict(
-            inner_loop_payload,
-            base_dir=base_dir,
-        )
-    return LoopsConfig(
-        version=_load_config_version(payload),
-        task_provider_id=task_provider_id,
-        task_provider_config=task_provider_config,
-        loop_config=loop_config,
-        inner_loop=inner_loop,
-    )
-
-
-def upgrade_config_payload(payload: Any) -> tuple[dict[str, Any], bool]:
-    """Upgrade a config payload in-memory to the latest schema version."""
-
-    if not isinstance(payload, dict):
-        raise TypeError("Config must be a JSON object")
-    upgraded = dict(payload)
-    changed = False
-    version = _load_config_version(upgraded)
-
-    if version > LATEST_LOOPS_CONFIG_VERSION:
-        raise ValueError(
-            f"Unsupported config version: {version}. "
-            f"Latest supported version is {LATEST_LOOPS_CONFIG_VERSION}."
-        )
-
-    if version < LATEST_LOOPS_CONFIG_VERSION:
-        upgraded["version"] = LATEST_LOOPS_CONFIG_VERSION
-        changed = True
-
-    legacy_provider_id = upgraded.pop("provider_id", None)
-    if legacy_provider_id is not None:
-        changed = True
-        if "task_provider_id" not in upgraded:
-            upgraded["task_provider_id"] = legacy_provider_id
-
-    legacy_provider_config = upgraded.pop("provider_config", None)
-    if legacy_provider_config is not None:
-        changed = True
-        if "task_provider_config" not in upgraded:
-            upgraded["task_provider_config"] = legacy_provider_config
-
-    existing_loop_payload = upgraded.get("loop_config")
-    if existing_loop_payload is None:
-        loop_payload: dict[str, Any] = {}
-    elif isinstance(existing_loop_payload, dict):
-        loop_payload = dict(existing_loop_payload)
-    else:
-        raise TypeError("loop_config must be an object")
-
-    for key, value in build_default_loop_config_payload().items():
-        if key not in loop_payload:
-            loop_payload[key] = value
-            changed = True
-
-    if existing_loop_payload != loop_payload:
-        upgraded["loop_config"] = loop_payload
-
-    task_provider_id = upgraded.get("task_provider_id")
-    if task_provider_id == GITHUB_PROJECTS_V2_PROVIDER_ID:
-        existing_provider_payload = upgraded.get("task_provider_config")
-        if existing_provider_payload is None:
-            provider_payload: dict[str, Any] = {}
-        elif isinstance(existing_provider_payload, dict):
-            provider_payload = dict(existing_provider_payload)
-        else:
-            raise TypeError("task_provider_config must be an object")
-        project_url = provider_payload.get("url")
-        if not isinstance(project_url, str) or not project_url.strip():
-            provider_defaults = build_default_provider_config_payload()
-        else:
-            provider_defaults = build_default_provider_config_payload(
-                project_url=project_url,
-            )
-        for key, value in provider_defaults.items():
-            if key == "url":
-                continue
-            if key not in provider_payload:
-                provider_payload[key] = value
-                changed = True
-        if existing_provider_payload != provider_payload:
-            upgraded["task_provider_config"] = provider_payload
-
-    return upgraded, changed
-
-
 def build_provider(config: LoopsConfig) -> TaskProvider:
     """Construct the task provider for the configured provider id."""
 
@@ -634,97 +438,6 @@ def _inner_loop_runs_root(loops_root: Path) -> Path:
     return loops_root / INNER_LOOP_RUNS_DIR_NAME
 
 
-def _load_outer_loop_config(payload: Any) -> OuterLoopConfig:
-    """Load outer loop configuration from JSON payload."""
-
-    if payload is None:
-        raw_payload: dict[str, Any] = {}
-    elif isinstance(payload, dict):
-        raw_payload = payload
-    else:
-        raise TypeError("loop_config must be an object")
-    defaults = build_default_loop_config_payload()
-    merged_payload = {**defaults, **raw_payload}
-    poll_interval = _load_int(
-        merged_payload,
-        "poll_interval_seconds",
-        defaults["poll_interval_seconds"],
-    )
-    if poll_interval <= 0:
-        raise ValueError("poll_interval_seconds must be positive")
-    parallel_limit = _load_int(
-        merged_payload,
-        "parallel_tasks_limit",
-        defaults["parallel_tasks_limit"],
-    )
-    if parallel_limit <= 0:
-        raise ValueError("parallel_tasks_limit must be positive")
-    return OuterLoopConfig(
-        poll_interval_seconds=poll_interval,
-        parallel_tasks=_load_bool(
-            merged_payload,
-            "parallel_tasks",
-            defaults["parallel_tasks"],
-        ),
-        parallel_tasks_limit=parallel_limit,
-        sync_mode=_load_bool(merged_payload, "sync_mode", defaults["sync_mode"]),
-        emit_on_first_run=_load_bool(
-            merged_payload,
-            "emit_on_first_run",
-            defaults["emit_on_first_run"],
-        ),
-        force=_load_bool(merged_payload, "force", defaults["force"]),
-        task_ready_status=_load_str(
-            merged_payload,
-            "task_ready_status",
-            defaults["task_ready_status"],
-        ),
-        approval_comment_usernames=normalize_approval_usernames(
-            _load_str_list(
-                merged_payload,
-                "approval_comment_usernames",
-                tuple(defaults["approval_comment_usernames"]),
-            )
-        ),
-        approval_comment_pattern=_load_str(
-            merged_payload,
-            "approval_comment_pattern",
-            defaults["approval_comment_pattern"],
-        ),
-        auto_approve_enabled=_load_bool(
-            merged_payload,
-            "auto_approve_enabled",
-            defaults["auto_approve_enabled"],
-        ),
-        handoff_handler=validate_handoff_handler_name(
-            _load_str(
-                merged_payload,
-                "handoff_handler",
-                defaults["handoff_handler"],
-            )
-        ),
-    )
-
-
-def build_default_loop_config_payload() -> dict[str, Any]:
-    """Build the canonical loop_config defaults payload for JSON config files."""
-
-    defaults = OuterLoopConfig()
-    return {
-        "poll_interval_seconds": defaults.poll_interval_seconds,
-        "parallel_tasks": defaults.parallel_tasks,
-        "parallel_tasks_limit": defaults.parallel_tasks_limit,
-        "sync_mode": defaults.sync_mode,
-        "emit_on_first_run": defaults.emit_on_first_run,
-        "force": defaults.force,
-        "task_ready_status": defaults.task_ready_status,
-        "approval_comment_usernames": list(defaults.approval_comment_usernames),
-        "approval_comment_pattern": defaults.approval_comment_pattern,
-        "auto_approve_enabled": defaults.auto_approve_enabled,
-        "handoff_handler": defaults.handoff_handler,
-    }
-
-
 def _validate_required_secrets(
     provider: LoopsProviderConfig,
     *,
@@ -761,61 +474,6 @@ def _resolve_secret_env_name(
         if value is not None and value.strip():
             return env_name
     return None
-
-
-def _load_bool(payload: dict[str, Any], key: str, default: bool) -> bool:
-    """Load a boolean config value with validation."""
-
-    value = payload.get(key, default)
-    if not isinstance(value, bool):
-        raise TypeError(f"{key} must be a boolean")
-    return value
-
-
-def _load_int(payload: dict[str, Any], key: str, default: int) -> int:
-    """Load an integer config value with validation."""
-
-    value = payload.get(key, default)
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise TypeError(f"{key} must be an integer")
-    return value
-
-
-def _load_str(payload: dict[str, Any], key: str, default: str) -> str:
-    """Load a string config value with validation."""
-
-    value = payload.get(key, default)
-    if not isinstance(value, str):
-        raise TypeError(f"{key} must be a string")
-    return value
-
-
-def _load_str_list(
-    payload: dict[str, Any],
-    key: str,
-    default: tuple[str, ...],
-) -> tuple[str, ...]:
-    """Load a list of strings with validation."""
-
-    value = payload.get(key, default)
-    if isinstance(value, tuple):
-        candidate = list(value)
-    else:
-        candidate = value
-    if not isinstance(candidate, list) or not all(
-        isinstance(item, str) for item in candidate
-    ):
-        raise TypeError(f"{key} must be a list of strings")
-    return tuple(candidate)
-
-
-def _load_config_version(payload: dict[str, Any]) -> int:
-    value = payload.get("version", 0)
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise TypeError("version must be an integer")
-    if value < 0:
-        raise ValueError("version must be >= 0")
-    return value
 
 
 def _is_ready(task: Task, config: OuterLoopConfig) -> bool:

--- a/loops/utils/__init__.py
+++ b/loops/utils/__init__.py
@@ -1,0 +1,2 @@
+"""Utility helpers for the Loops package."""
+

--- a/loops/utils/config.py
+++ b/loops/utils/config.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+"""Config types and parsing utilities for Loops."""
+
+from dataclasses import dataclass
+import json
+import shlex
+from pathlib import Path
+from typing import Any, Optional
+
+from loops.approval_config import (
+    DEFAULT_APPROVAL_COMMENT_PATTERN,
+    normalize_approval_usernames,
+)
+from loops.handoff_handlers import (
+    DEFAULT_HANDOFF_HANDLER,
+    validate_handoff_handler_name,
+    validate_handoff_handler_provider_compatibility,
+)
+from loops.providers.github_projects_v2 import (
+    GITHUB_PROJECTS_V2_PROVIDER_ID,
+    build_default_provider_config_payload,
+)
+
+LATEST_LOOPS_CONFIG_VERSION = 2
+
+
+@dataclass(frozen=True)
+class OuterLoopConfig:
+    """Configuration for the outer loop polling and dispatch behavior."""
+
+    poll_interval_seconds: int = 30
+    parallel_tasks: bool = False
+    parallel_tasks_limit: int = 5
+    sync_mode: bool = False
+    emit_on_first_run: bool = False
+    force: bool = False
+    task_ready_status: str = "Ready"
+    approval_comment_usernames: tuple[str, ...] = ()
+    approval_comment_pattern: str = DEFAULT_APPROVAL_COMMENT_PATTERN
+    auto_approve_enabled: bool = False
+    handoff_handler: str = DEFAULT_HANDOFF_HANDLER
+
+
+@dataclass(frozen=True)
+class InnerLoopCommandConfig:
+    """Configuration for launching inner loop commands."""
+
+    command: list[str]
+    working_dir: Optional[str] = None
+    env: Optional[dict[str, str]] = None
+    append_task_url: bool = True
+
+    @staticmethod
+    def from_dict(
+        payload: dict[str, Any],
+        *,
+        base_dir: Optional[Path] = None,
+    ) -> "InnerLoopCommandConfig":
+        """Build an InnerLoopCommandConfig from a dict payload."""
+
+        if "command" not in payload:
+            raise KeyError("inner_loop.command is required")
+        raw_command = payload["command"]
+        if isinstance(raw_command, str):
+            command = shlex.split(raw_command)
+        elif isinstance(raw_command, list) and all(
+            isinstance(item, str) for item in raw_command
+        ):
+            command = list(raw_command)
+        else:
+            raise TypeError("inner_loop.command must be a string or list of strings")
+        if not command:
+            raise ValueError("inner_loop.command cannot be empty")
+        working_dir = payload.get("working_dir")
+        if working_dir is not None and not isinstance(working_dir, str):
+            raise TypeError("inner_loop.working_dir must be a string")
+        if working_dir is not None and base_dir is not None:
+            working_path = Path(working_dir)
+            if not working_path.is_absolute():
+                working_dir = str((base_dir / working_path).resolve())
+        env = payload.get("env")
+        if env is not None:
+            if not isinstance(env, dict) or not all(
+                isinstance(key, str) and isinstance(value, str)
+                for key, value in env.items()
+            ):
+                raise TypeError("inner_loop.env must be a string-to-string map")
+        append_task_url = payload.get("append_task_url", True)
+        if not isinstance(append_task_url, bool):
+            raise TypeError("inner_loop.append_task_url must be a boolean")
+        return InnerLoopCommandConfig(
+            command=command,
+            working_dir=working_dir,
+            env=env,
+            append_task_url=append_task_url,
+        )
+
+
+@dataclass(frozen=True)
+class LoopsConfig:
+    """Top-level Loops configuration loaded from JSON."""
+
+    version: int
+    task_provider_id: str
+    task_provider_config: dict[str, Any]
+    loop_config: OuterLoopConfig
+    inner_loop: Optional[InnerLoopCommandConfig] = None
+
+
+def load_config(path: str | Path) -> LoopsConfig:
+    """Load a LoopsConfig from a JSON file."""
+
+    payload = json.loads(Path(path).read_text())
+    payload, _ = upgrade_config_payload(payload)
+    task_provider_id = payload.get("task_provider_id")
+    if not isinstance(task_provider_id, str) or not task_provider_id:
+        raise TypeError("task_provider_id is required and must be a string")
+    task_provider_config = payload.get("task_provider_config")
+    if not isinstance(task_provider_config, dict):
+        raise TypeError("task_provider_config must be an object")
+    loop_config = _load_outer_loop_config(payload.get("loop_config"))
+    validate_handoff_handler_provider_compatibility(
+        loop_config.handoff_handler,
+        task_provider_id,
+    )
+    inner_loop_payload = payload.get("inner_loop")
+    inner_loop = None
+    if inner_loop_payload is not None:
+        if not isinstance(inner_loop_payload, dict):
+            raise TypeError("inner_loop must be an object")
+        base_dir = Path(path).resolve().parent
+        inner_loop = InnerLoopCommandConfig.from_dict(
+            inner_loop_payload,
+            base_dir=base_dir,
+        )
+    return LoopsConfig(
+        version=_load_config_version(payload),
+        task_provider_id=task_provider_id,
+        task_provider_config=task_provider_config,
+        loop_config=loop_config,
+        inner_loop=inner_loop,
+    )
+
+
+def upgrade_config_payload(payload: Any) -> tuple[dict[str, Any], bool]:
+    """Upgrade a config payload in-memory to the latest schema version."""
+
+    if not isinstance(payload, dict):
+        raise TypeError("Config must be a JSON object")
+    upgraded = dict(payload)
+    changed = False
+    version = _load_config_version(upgraded)
+
+    if version > LATEST_LOOPS_CONFIG_VERSION:
+        raise ValueError(
+            f"Unsupported config version: {version}. "
+            f"Latest supported version is {LATEST_LOOPS_CONFIG_VERSION}."
+        )
+
+    if version < LATEST_LOOPS_CONFIG_VERSION:
+        upgraded["version"] = LATEST_LOOPS_CONFIG_VERSION
+        changed = True
+
+    legacy_provider_id = upgraded.pop("provider_id", None)
+    if legacy_provider_id is not None:
+        changed = True
+        if "task_provider_id" not in upgraded:
+            upgraded["task_provider_id"] = legacy_provider_id
+
+    legacy_provider_config = upgraded.pop("provider_config", None)
+    if legacy_provider_config is not None:
+        changed = True
+        if "task_provider_config" not in upgraded:
+            upgraded["task_provider_config"] = legacy_provider_config
+
+    existing_loop_payload = upgraded.get("loop_config")
+    if existing_loop_payload is None:
+        loop_payload: dict[str, Any] = {}
+    elif isinstance(existing_loop_payload, dict):
+        loop_payload = dict(existing_loop_payload)
+    else:
+        raise TypeError("loop_config must be an object")
+
+    for key, value in build_default_loop_config_payload().items():
+        if key not in loop_payload:
+            loop_payload[key] = value
+            changed = True
+
+    if existing_loop_payload != loop_payload:
+        upgraded["loop_config"] = loop_payload
+
+    task_provider_id = upgraded.get("task_provider_id")
+    if task_provider_id == GITHUB_PROJECTS_V2_PROVIDER_ID:
+        existing_provider_payload = upgraded.get("task_provider_config")
+        if existing_provider_payload is None:
+            provider_payload: dict[str, Any] = {}
+        elif isinstance(existing_provider_payload, dict):
+            provider_payload = dict(existing_provider_payload)
+        else:
+            raise TypeError("task_provider_config must be an object")
+        project_url = provider_payload.get("url")
+        if not isinstance(project_url, str) or not project_url.strip():
+            provider_defaults = build_default_provider_config_payload()
+        else:
+            provider_defaults = build_default_provider_config_payload(
+                project_url=project_url,
+            )
+        for key, value in provider_defaults.items():
+            if key == "url":
+                continue
+            if key not in provider_payload:
+                provider_payload[key] = value
+                changed = True
+        if existing_provider_payload != provider_payload:
+            upgraded["task_provider_config"] = provider_payload
+
+    return upgraded, changed
+
+
+def build_default_loop_config_payload() -> dict[str, Any]:
+    """Build the canonical loop_config defaults payload for JSON config files."""
+
+    defaults = OuterLoopConfig()
+    return {
+        "poll_interval_seconds": defaults.poll_interval_seconds,
+        "parallel_tasks": defaults.parallel_tasks,
+        "parallel_tasks_limit": defaults.parallel_tasks_limit,
+        "sync_mode": defaults.sync_mode,
+        "emit_on_first_run": defaults.emit_on_first_run,
+        "force": defaults.force,
+        "task_ready_status": defaults.task_ready_status,
+        "approval_comment_usernames": list(defaults.approval_comment_usernames),
+        "approval_comment_pattern": defaults.approval_comment_pattern,
+        "auto_approve_enabled": defaults.auto_approve_enabled,
+        "handoff_handler": defaults.handoff_handler,
+    }
+
+
+def _load_outer_loop_config(payload: Any) -> OuterLoopConfig:
+    """Load outer loop configuration from JSON payload."""
+
+    if payload is None:
+        raw_payload: dict[str, Any] = {}
+    elif isinstance(payload, dict):
+        raw_payload = payload
+    else:
+        raise TypeError("loop_config must be an object")
+    defaults = build_default_loop_config_payload()
+    merged_payload = {**defaults, **raw_payload}
+    poll_interval = _load_int(
+        merged_payload,
+        "poll_interval_seconds",
+        defaults["poll_interval_seconds"],
+    )
+    if poll_interval <= 0:
+        raise ValueError("poll_interval_seconds must be positive")
+    parallel_limit = _load_int(
+        merged_payload,
+        "parallel_tasks_limit",
+        defaults["parallel_tasks_limit"],
+    )
+    if parallel_limit <= 0:
+        raise ValueError("parallel_tasks_limit must be positive")
+    return OuterLoopConfig(
+        poll_interval_seconds=poll_interval,
+        parallel_tasks=_load_bool(
+            merged_payload,
+            "parallel_tasks",
+            defaults["parallel_tasks"],
+        ),
+        parallel_tasks_limit=parallel_limit,
+        sync_mode=_load_bool(merged_payload, "sync_mode", defaults["sync_mode"]),
+        emit_on_first_run=_load_bool(
+            merged_payload,
+            "emit_on_first_run",
+            defaults["emit_on_first_run"],
+        ),
+        force=_load_bool(merged_payload, "force", defaults["force"]),
+        task_ready_status=_load_str(
+            merged_payload,
+            "task_ready_status",
+            defaults["task_ready_status"],
+        ),
+        approval_comment_usernames=normalize_approval_usernames(
+            _load_str_list(
+                merged_payload,
+                "approval_comment_usernames",
+                tuple(defaults["approval_comment_usernames"]),
+            )
+        ),
+        approval_comment_pattern=_load_str(
+            merged_payload,
+            "approval_comment_pattern",
+            defaults["approval_comment_pattern"],
+        ),
+        auto_approve_enabled=_load_bool(
+            merged_payload,
+            "auto_approve_enabled",
+            defaults["auto_approve_enabled"],
+        ),
+        handoff_handler=validate_handoff_handler_name(
+            _load_str(
+                merged_payload,
+                "handoff_handler",
+                defaults["handoff_handler"],
+            )
+        ),
+    )
+
+
+def _load_bool(payload: dict[str, Any], key: str, default: bool) -> bool:
+    """Load a boolean config value with validation."""
+
+    value = payload.get(key, default)
+    if not isinstance(value, bool):
+        raise TypeError(f"{key} must be a boolean")
+    return value
+
+
+def _load_int(payload: dict[str, Any], key: str, default: int) -> int:
+    """Load an integer config value with validation."""
+
+    value = payload.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{key} must be an integer")
+    return value
+
+
+def _load_str(payload: dict[str, Any], key: str, default: str) -> str:
+    """Load a string config value with validation."""
+
+    value = payload.get(key, default)
+    if not isinstance(value, str):
+        raise TypeError(f"{key} must be a string")
+    return value
+
+
+def _load_str_list(
+    payload: dict[str, Any],
+    key: str,
+    default: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Load a list of strings with validation."""
+
+    value = payload.get(key, default)
+    if isinstance(value, tuple):
+        candidate = list(value)
+    else:
+        candidate = value
+    if not isinstance(candidate, list) or not all(
+        isinstance(item, str) for item in candidate
+    ):
+        raise TypeError(f"{key} must be a list of strings")
+    return tuple(candidate)
+
+
+def _load_config_version(payload: dict[str, Any]) -> int:
+    value = payload.get("version", 0)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("version must be an integer")
+    if value < 0:
+        raise ValueError("version must be >= 0")
+    return value
+


### PR DESCRIPTION
refactor: centralize loops config parsing in utils/config.py

## Context
- move Loops config models and parsing/upgrade helpers from `loops/outer_loop.py` into `loops/utils/config.py`
- keep `loops.outer_loop` import surface stable by importing/re-exporting config APIs there
- add a focused flow doc for force behavior: `docs/flows/ref.force-option.md`

## Testing
- [x] `PYTHONPATH=. pytest`
- [x] `PYTHONPATH=. pytest tests/test_outer_loop.py tests/test_cli.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation describing Force Option Flow behavior and control flow.

* **New Features**
  * Introduced JSON-based configuration system with validation and automatic upgrade support for legacy configurations.
  * Added support for inner loop command configuration with environment variable and working directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->