### PR TITLE
remove inner_loop_approval_config.json

### DIFF
--- a/docs/flows/ref.inner-loop.md
+++ b/docs/flows/ref.inner-loop.md
@@ -161,12 +161,9 @@ None identified.
 ```ts
 function runInnerLoop(runDir: Path, opts: Options): RunRecord {
   initializePathsAndDefaults(runDir, opts)
-  commentApproval = loadCommentApprovalSettings(runDir) // reads inner_loop_runtime_config.json
-  if (commentApproval.configLoadError) {
-    log("[loops] failed to load run approval config; using defaults")
-  }
+  commentApproval = loadCommentApprovalSettings(runtimeConfig) // reads approval fields from inner_loop_runtime_config.json
   if (commentApproval.usedDefaultPattern) {
-    log("[loops] invalid approval comment pattern in run approval config; falling back to default")
+    log("[loops] invalid approval comment pattern in run runtime config; falling back to default")
   }
   if (prStatusFetcher is null) {
     prStatusFetcher = (pr) => {
@@ -338,6 +335,7 @@ A: Inner loop only.
 
 ## Changelog
 - 2026-03-02: Documented run-record checkout metadata (`checkout_mode`, `starting_commit`) and worktree setup instruction injection on initial RUNNING prompts. (019cabf2-f02b-7521-b814-5b0fcafe3d34)
+- 2026-03-02: Removed legacy `inner_loop_approval_config.json` fallback; comment-approval settings now load only from `inner_loop_runtime_config.json`. (019cabe9-52d6-73a2-b856-da28851da5b5)
 - 2026-03-01: Removed state-signal queue references after deleting `loops signal`/`loops.state_signal`; NEEDS_INPUT now documents direct `run.json` handoff behavior. (019cabbd-8be2-7f00-ba1e-0856ed6096dc)
 - 2026-03-01: Added deterministic best-effort 👍 reactions for allowlisted plain-comment approval signals during `WAITING_ON_REVIEW` polling. (019cab4c-0485-7542-b9eb-ff1c83ca0942)
 - 2026-03-01: Documented `run.json.stream_logs_stdout` persistence as the effective log-streaming snapshot loaded from runtime config/env fallbacks. (019cab67-3061-7ce1-81c1-e30f80798fb0)

--- a/docs/specs/active/2026-02-09-create-integration-testing-harness-for-loops.md
+++ b/docs/specs/active/2026-02-09-create-integration-testing-harness-for-loops.md
@@ -71,7 +71,7 @@ We need an end-to-end integration test that validates the GitHub Projects v2 pro
 ### Important Context
 - Provider poll order is oldest-first after filter application; tests should avoid relying on global board ordering.
 - Outer loop creates run dirs under `.loops/jobs/` and writes `run.json` when it emits tasks.
-- Outer loop materializes `run.json`, `run.log`, `agent.log`, and run-scoped approval config before launch.
+- Outer loop materializes `run.json`, `run.log`, `agent.log`, and `inner_loop_runtime_config.json` before launch.
 - `loops run --run-once` is the canonical command for one cycle.
 - For clarity and control, the integration config should set an explicit `inner_loop.command` that executes Loops inner loop (which in turn invokes Codex).
 

--- a/docs/specs/active/2026-02-17-allow-comment-based-pr-approval.md
+++ b/docs/specs/active/2026-02-17-allow-comment-based-pr-approval.md
@@ -219,7 +219,7 @@ Manual validation:
 
 ## Notes
 
-- Simplification: keep user-facing configuration in provider config; inner-loop reads run-scoped approval config materialized by outer loop.
+- Simplification: keep user-facing configuration in provider config; inner-loop reads approval settings from run-scoped `inner_loop_runtime_config.json` materialized by outer loop.
 - Simplification: keep `RunPR` schema unchanged; only review-status computation is extended.
 
 ## Manual Notes 
@@ -227,6 +227,7 @@ Manual validation:
 [keep this for the user to add notes. do not change between edits]
 
 ## Changelog
+- 2026-03-02: Removed legacy `inner_loop_approval_config.json` fallback; comment approval now loads only from `inner_loop_runtime_config.json`. (019cabe9-52d6-73a2-b856-da28851da5b5)
 - 2026-03-02: Moved approval comment settings from `loop_config` to GitHub provider config and updated doctor/config docs accordingly. (019cabd8-6116-7542-aead-8d1fd6d6b985)
 - 2026-03-01: Added deterministic best-effort 👍 reactions when an allowlisted plain PR comment is the winning approval signal in review polling. (019cab4c-0485-7542-b9eb-ff1c83ca0942)
 - 2026-02-17: Created initial feature spec for allowlisted comment-based PR approval override. (019c68ed-a6c5-78e0-891a-6b70a1a1450c)

--- a/docs/specs/active/2026-03-01-harness-engineering-for-loops.md
+++ b/docs/specs/active/2026-03-01-harness-engineering-for-loops.md
@@ -157,7 +157,7 @@ Implement harness engineering as five practical workstreams aligned to OpenAI gu
 - [ ] Implement `scripts/harness/check_runtime_invariants.py`:
   - verify `derive_run_state` precedence invariants.
   - verify outer-loop defaults alignment between init/doctor/runtime loaders.
-  - verify required run artifacts are created during scheduling (`run.json`, `run.log`, `agent.log`, approval config).
+  - verify required run artifacts are created during scheduling (`run.json`, `run.log`, `agent.log`, `inner_loop_runtime_config.json`).
 - [ ] Wire harness checks into test/CI pathways via:
   - [Makefile](/Users/kevinlin/.worktrees/loops/dev/2026-02-09-create-integration-testing-harness-for-loops/Makefile)
   - [tests/test_cli.py](/Users/kevinlin/.worktrees/loops/dev/2026-02-09-create-integration-testing-harness-for-loops/tests/test_cli.py)

--- a/loops/approval_config.py
+++ b/loops/approval_config.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Mapping
 
 DEFAULT_APPROVAL_COMMENT_PATTERN = r"^\s*/approve\b"
-INNER_LOOP_APPROVAL_CONFIG_FILE = "inner_loop_approval_config.json"
 
 
 def normalize_approval_usernames(usernames: Iterable[str]) -> tuple[str, ...]:
@@ -22,81 +17,3 @@ def normalize_approval_usernames(usernames: Iterable[str]) -> tuple[str, ...]:
         normalized.append(candidate)
         seen.add(candidate)
     return tuple(normalized)
-
-
-@dataclass(frozen=True)
-class InnerLoopApprovalConfig:
-    approval_comment_usernames: tuple[str, ...] = ()
-    approval_comment_pattern: str = DEFAULT_APPROVAL_COMMENT_PATTERN
-    review_actor_usernames: tuple[str, ...] = ()
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "approval_comment_usernames": list(self.approval_comment_usernames),
-            "approval_comment_pattern": self.approval_comment_pattern,
-            "review_actor_usernames": list(self.review_actor_usernames),
-        }
-
-
-def build_inner_loop_approval_config(
-    *,
-    approval_comment_usernames: Iterable[str],
-    approval_comment_pattern: str,
-    review_actor_usernames: Iterable[str] = (),
-) -> InnerLoopApprovalConfig:
-    return InnerLoopApprovalConfig(
-        approval_comment_usernames=normalize_approval_usernames(
-            approval_comment_usernames
-        ),
-        approval_comment_pattern=approval_comment_pattern or DEFAULT_APPROVAL_COMMENT_PATTERN,
-        review_actor_usernames=normalize_approval_usernames(review_actor_usernames),
-    )
-
-
-def write_inner_loop_approval_config(
-    run_dir: Path,
-    config: InnerLoopApprovalConfig,
-) -> Path:
-    """Persist run-scoped approval configuration for inner-loop polling."""
-
-    target = run_dir / INNER_LOOP_APPROVAL_CONFIG_FILE
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(config.to_dict(), indent=2, sort_keys=True))
-    return target
-
-
-def read_inner_loop_approval_config(run_dir: Path) -> InnerLoopApprovalConfig:
-    """Load run-scoped approval configuration with validation."""
-
-    target = run_dir / INNER_LOOP_APPROVAL_CONFIG_FILE
-    if not target.exists():
-        return InnerLoopApprovalConfig()
-    payload = json.loads(target.read_text())
-    if not isinstance(payload, Mapping):
-        raise TypeError("inner loop approval config must be an object")
-    raw_usernames = payload.get("approval_comment_usernames", ())
-    if isinstance(raw_usernames, tuple):
-        usernames_candidate = list(raw_usernames)
-    else:
-        usernames_candidate = raw_usernames
-    if not isinstance(usernames_candidate, list) or not all(
-        isinstance(item, str) for item in usernames_candidate
-    ):
-        raise TypeError("approval_comment_usernames must be a list of strings")
-    pattern = payload.get("approval_comment_pattern", DEFAULT_APPROVAL_COMMENT_PATTERN)
-    if not isinstance(pattern, str):
-        raise TypeError("approval_comment_pattern must be a string")
-    raw_review_usernames = payload.get("review_actor_usernames", ())
-    if isinstance(raw_review_usernames, tuple):
-        review_usernames_candidate = list(raw_review_usernames)
-    else:
-        review_usernames_candidate = raw_review_usernames
-    if not isinstance(review_usernames_candidate, list) or not all(
-        isinstance(item, str) for item in review_usernames_candidate
-    ):
-        raise TypeError("review_actor_usernames must be a list of strings")
-    return InnerLoopApprovalConfig(
-        approval_comment_usernames=normalize_approval_usernames(usernames_candidate),
-        approval_comment_pattern=pattern or DEFAULT_APPROVAL_COMMENT_PATTERN,
-        review_actor_usernames=normalize_approval_usernames(review_usernames_candidate),
-    )

--- a/loops/inner_loop.py
+++ b/loops/inner_loop.py
@@ -14,11 +14,7 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, cast
 
-from loops.approval_config import (
-    DEFAULT_APPROVAL_COMMENT_PATTERN,
-    InnerLoopApprovalConfig,
-    read_inner_loop_approval_config,
-)
+from loops.approval_config import DEFAULT_APPROVAL_COMMENT_PATTERN
 from loops.handoff_handlers import (
     DEFAULT_HANDOFF_HANDLER,
     HANDOFF_HANDLER_STDIN,
@@ -141,7 +137,6 @@ class CommentApprovalSettings:
     approval_regex: re.Pattern[str]
     review_actor_usernames: tuple[str, ...] = ()
     used_default_pattern: bool = False
-    config_load_error: str | None = None
 
     @property
     def enabled(self) -> bool:
@@ -306,22 +301,13 @@ def run_inner_loop(
             environ=runtime_environ,
         )
         comment_approval = _load_comment_approval_settings(
-            run_dir,
             runtime_config=runtime_config,
         )
-        if comment_approval.config_load_error is not None:
-            append_log(
-                run_log,
-                (
-                    "[loops] failed to load run approval config; using defaults: "
-                    f"{comment_approval.config_load_error}"
-                ),
-            )
         if comment_approval.used_default_pattern:
             append_log(
                 run_log,
                 (
-                    "[loops] invalid approval comment pattern in run approval config; "
+                    "[loops] invalid approval comment pattern in run runtime config; "
                     "falling back to default"
                 ),
             )
@@ -1972,25 +1958,18 @@ def _ci_status_from_rollup(payload: dict[str, Any]) -> str:
 
 
 def _load_comment_approval_settings(
-    run_dir: Path,
     *,
     runtime_config: InnerLoopRuntimeConfig | None = None,
 ) -> CommentApprovalSettings:
-    config_load_error: str | None = None
+    allowed_usernames = ()
+    review_actor_usernames = ()
+    pattern_text = DEFAULT_APPROVAL_COMMENT_PATTERN
     if runtime_config is not None:
-        config = InnerLoopApprovalConfig(
-            approval_comment_usernames=runtime_config.approval_comment_usernames,
-            approval_comment_pattern=runtime_config.approval_comment_pattern,
-            review_actor_usernames=runtime_config.review_actor_usernames,
+        allowed_usernames = runtime_config.approval_comment_usernames
+        review_actor_usernames = runtime_config.review_actor_usernames
+        pattern_text = (
+            runtime_config.approval_comment_pattern or DEFAULT_APPROVAL_COMMENT_PATTERN
         )
-    else:
-        try:
-            config = read_inner_loop_approval_config(run_dir)
-        except Exception as exc:
-            config_load_error = str(exc)
-            config = InnerLoopApprovalConfig()
-    allowed_usernames = config.approval_comment_usernames
-    pattern_text = config.approval_comment_pattern or DEFAULT_APPROVAL_COMMENT_PATTERN
     used_default_pattern = False
     try:
         approval_regex = re.compile(pattern_text, re.IGNORECASE)
@@ -2000,11 +1979,10 @@ def _load_comment_approval_settings(
         used_default_pattern = True
     return CommentApprovalSettings(
         allowed_usernames=allowed_usernames,
-        review_actor_usernames=config.review_actor_usernames,
+        review_actor_usernames=review_actor_usernames,
         pattern_text=pattern_text,
         approval_regex=approval_regex,
         used_default_pattern=used_default_pattern,
-        config_load_error=config_load_error,
     )
 
 

--- a/tests/test_inner_loop.py
+++ b/tests/test_inner_loop.py
@@ -15,7 +15,6 @@ import pytest
 
 from loops.approval_config import (
     DEFAULT_APPROVAL_COMMENT_PATTERN,
-    INNER_LOOP_APPROVAL_CONFIG_FILE,
 )
 from loops.handoff_handlers import HandoffResult
 from loops.inner_loop_runtime_config import (
@@ -3786,19 +3785,14 @@ def test_fetch_pr_status_does_not_override_newer_changes_requested(monkeypatch) 
 
 
 def test_load_comment_approval_settings_invalid_pattern_falls_back(tmp_path) -> None:
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    (run_dir / INNER_LOOP_APPROVAL_CONFIG_FILE).write_text(
-        json.dumps(
-            {
-                "approval_comment_usernames": ["Maintainer"],
-                "approval_comment_pattern": "[",
-                "review_actor_usernames": ["Reviewer"],
-            }
-        )
+    runtime_config = InnerLoopRuntimeConfig(
+        approval_comment_usernames=("maintainer",),
+        approval_comment_pattern="[",
+        review_actor_usernames=("reviewer",),
     )
-
-    settings = inner_loop_module._load_comment_approval_settings(run_dir)
+    settings = inner_loop_module._load_comment_approval_settings(
+        runtime_config=runtime_config
+    )
 
     assert settings.allowed_usernames == ("maintainer",)
     assert settings.review_actor_usernames == ("reviewer",)


### PR DESCRIPTION
Related issue:
- https://github.com/kevinslin/loops/issues/52

Summary:
- remove legacy `inner_loop_approval_config.json` transport/read-path support
- source comment-approval settings only from `inner_loop_runtime_config.json` materialized by outer loop
- drop unused approval-config read/write helpers and update docs/spec flow references accordingly

Validation:
- `python -m pytest`

sessionid: 019cabe9-52d6-73a2-b856-da28851da5b5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references to reflect comment approval configuration now loads from unified runtime config instead of separate configuration files.

* **Chores**
  * Removed legacy inner_loop_approval_config.json fallback; comment approval settings now load only from inner_loop_runtime_config.json.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->