### PR TITLE
feat: add handoff subcommand for loops takeover

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -635,6 +635,7 @@ Practical invariant: if this skill contract changes, update `loops/core/inner_lo
 - `python -m loops init` initializes `.loops/` scaffolding (`jobs/`, logs, state, default config).
 - `python -m loops doctor` upgrades config schema/default values in `config.json`.
 - `python -m loops run` starts the outer loop runner.
+- `python -m loops handoff [session-id]` seeds a run from Codex conversation context (PR + tracking task), defaults that run to `WAITING_ON_REVIEW`, and launches the configured inner-loop command.
 - `python -m loops inner-loop` runs one inner-loop execution for a run directory.
 - `python -m loops clean` deletes empty runs and archives completed runs.
 - `python -m loops.cli` is intentionally unsupported; use `loops ...` or `python -m loops ...`.
@@ -731,6 +732,7 @@ Prompt-related configuration and runtime inputs:
 ## 7. PR review and merge gate handling
 
 - For initial PR creation, `scripts/push-pr.py` writes `${LOOPS_RUN_DIR}/push-pr.url`; after a successful `RUNNING` turn, inner loop reads that artifact only when `run.json.pr` is missing, then records the PR in `run.json`.
+- `loops handoff [session-id]` can seed `run.json.pr` directly from conversation-derived PR URL and sets `pr.review_addressed_at = null` so all existing review/comment feedback is treated as unread on first `WAITING_ON_REVIEW` poll.
 - The inner loop polls PR status and updates `pr.review_status`.
 - When a review requests changes, the inner loop records `latest_review_submitted_at` (the review's `submittedAt` timestamp from GitHub) and invokes Codex to address the feedback. After Codex runs, `review_addressed_at` is set to `latest_review_submitted_at`. On subsequent polls, the loop only re-invokes Codex if `latest_review_submitted_at > review_addressed_at`, indicating a genuinely new review event. This prevents duplicate fix attempts when the reviewer has not yet re-reviewed.
 - When status is still open (no formal review decision), the inner loop uses the newest timestamp between `COMMENTED` PR review and plain PR discussion comment events as its feedback signal. It uses the same `latest_review_submitted_at > review_addressed_at` guard to decide whether to resume Codex.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -300,9 +300,8 @@ Notes:
 - `loop_config.handoff_handler` selects built-in NEEDS_INPUT handoff behavior (`stdin_handler` default, `gh_comment_handler` for issue-comment handoff).
 - `loop_config.checkout_mode` sets checkout guidance for agent execution (`branch` default, `worktree` alternate).
 - `inner_loop` is optional when running via the CLI; if omitted, the CLI uses
-  a canonical default builder for `python -m loops inner-loop` with `append_task_url=false`.
-- `python -m loops run --task-url <task-url>` targets exactly one task from the provider poll, implies `run-once`, `force=true`, and `sync_mode=true`, and does not mutate `task_provider_config.url`.
-- Installed package entrypoint `loops` is equivalent to `python -m loops` and uses the same argv normalization.
+  a canonical default builder for `loops inner-loop` with `append_task_url=false`.
+- `loops run --task-url <task-url>` targets exactly one task from the provider poll, implies `run-once`, `force=true`, and `sync_mode=true`, and does not mutate `task_provider_config.url`.
 
 ### Environment variables
 - `GITHUB_TOKEN` or `GH_TOKEN`: required for GitHub provider startup checks (`GH_TOKEN` is supported as alias fallback).
@@ -312,7 +311,7 @@ Notes:
 - `LOOPS_HANDOFF_HANDLER`: direct/manual-run fallback built-in handoff handler name.
 - `LOOPS_TASK_ID`, `LOOPS_TASK_TITLE`, `LOOPS_TASK_URL`, `LOOPS_TASK_PROVIDER`: legacy fallback task metadata used only when resetting a run with missing `run.json`.
 - `LOOPS_STREAM_LOGS_STDOUT`: direct/manual-run fallback toggle for mirroring `run.log` lines to stdout.
-- Outer-loop-launched runs persist runtime settings in `inner_loop_runtime_config.json` under each run directory, instead of injecting config via child-process env vars. For custom launch commands that are not `loops inner-loop` (or `python -m loops inner-loop`), `inner_loop.env` remains merged into child env.
+- Outer-loop-launched runs persist runtime settings in `inner_loop_runtime_config.json` under each run directory, instead of injecting config via child-process env vars. For custom launch commands that are not `loops inner-loop`, `inner_loop.env` remains merged into child env.
 - Inner-loop provider resolution for deterministic state hooks validates provider-required secrets against the run's effective runtime environment (`inner_loop_runtime_config.json` env overrides + process env), so hook-backed status updates work when tokens are supplied via `inner_loop.env`.
 - When `inner_loop_runtime_config.json` exists but is malformed, inner loop startup fails fast instead of silently falling back to process environment defaults.
 
@@ -412,7 +411,7 @@ File organization plan for all existing `loops/` source files:
 | `loops/TODO.md` | `loops/TODO.md` | Local package TODO notes; keep in place. |
 | `loops/cli.py` | `loops/core/cli.py` | Removed legacy path; use canonical CLI module/entrypoint only. |
 | `loops/outer_loop.py` | `loops/core/outer_loop.py` | Removed legacy path; use canonical outer-loop module only. |
-| `loops/inner_loop.py` | `loops/core/inner_loop.py` | Removed legacy path; use `loops inner-loop` or `python -m loops inner-loop`. |
+| `loops/inner_loop.py` | `loops/core/inner_loop.py` | Removed legacy path; use `loops inner-loop`. |
 | `loops/handoff_handlers.py` | `loops/core/handoff_handlers.py` | Removed legacy path; import from `loops.core.handoff_handlers`. |
 | `loops/cleanup.py` | `loops/commands/clean.py` | Removed legacy path; clean behavior lives in command module. |
 | `loops/approval_config.py` | `loops/state/approval_config.py` | Removed legacy path; state/config model moved under `state`. |
@@ -631,14 +630,14 @@ Practical invariant: if this skill contract changes, update `loops/core/inner_lo
 
 ### CLI callers
 
-- `python -m loops` is the top-level wrapper CLI.
-- `python -m loops init` initializes `.loops/` scaffolding (`jobs/`, logs, state, default config).
-- `python -m loops doctor` upgrades config schema/default values in `config.json`.
-- `python -m loops run` starts the outer loop runner.
-- `python -m loops handoff [session-id]` seeds a run from Codex conversation context (PR + tracking task), defaults that run to `WAITING_ON_REVIEW`, and launches the configured inner-loop command.
-- `python -m loops inner-loop` runs one inner-loop execution for a run directory.
-- `python -m loops clean` deletes empty runs and archives completed runs.
-- `python -m loops.cli` is intentionally unsupported; use `loops ...` or `python -m loops ...`.
+- `loops` is the top-level CLI.
+- `loops init` initializes `.loops/` scaffolding (`jobs/`, logs, state, default config).
+- `loops doctor` upgrades config schema/default values in `config.json`.
+- `loops run` starts the outer loop runner.
+- `loops handoff [session-id]` seeds a run from Codex conversation context (PR + tracking task), defaults that run to `WAITING_ON_REVIEW`, and launches the configured inner-loop command.
+- `loops inner-loop` runs one inner-loop execution for a run directory.
+- `loops clean` deletes empty runs and archives completed runs.
+- `loops.cli` is intentionally unsupported; use `loops ...`.
 
 ### Live integration harness targets
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ loops run --run-once
 loops run
 ```
 
-`python -m loops ...` remains supported as an equivalent invocation.
-
 ## Runtime layout
 
 Loops writes runtime state under `.loops/`:
@@ -107,8 +105,8 @@ Top-level config file: `.loops/config.json`
 - `inner_loop.env` (object string->string, optional): run-scoped inner-loop runtime env map (for example `CODEX_CMD`, prompt-file envs, or subprocess tokens) persisted to each run's `inner_loop_runtime_config.json`.
 - `inner_loop.append_task_url` (boolean, default `true`)
 
-If `inner_loop` is omitted and you run via `python -m loops`, the CLI injects:
-- `command = [sys.executable, "-m", "loops", "inner-loop"]`
+If `inner_loop` is omitted, the CLI injects:
+- `command` equivalent to `loops inner-loop`
 - `append_task_url = false`
 
 ## CLI reference
@@ -142,7 +140,6 @@ loops clean --dry-run
 Legacy compatibility:
 
 - `loops --run-once` is accepted and routed to `loops run --run-once`.
-- `python -m loops --run-once` is accepted and routed to `python -m loops run --run-once`.
 
 ### `loops run`
 
@@ -180,7 +177,7 @@ Notes:
 - URL matching for `--task-url` compares normalized URLs (scheme/host case-insensitive, query/fragment removed, trailing slash ignored).
 - `--task-url` bypasses ready-status filtering for the selected task and raises an error when the URL is missing or ambiguous in poll results.
 - Provider filters (`task_provider_config.filters`) are applied during provider polling before outer-loop status filtering.
-- Outer loop always injects `LOOPS_RUN_DIR` into launched inner-loop processes. For custom commands that are not `loops inner-loop` (or `python -m loops inner-loop`), `inner_loop.env` is also merged into child env; for Loops inner-loop commands, runtime settings are read from run-scoped `inner_loop_runtime_config.json`.
+- Outer loop always injects `LOOPS_RUN_DIR` into launched inner-loop processes. For custom commands that are not `loops inner-loop`, `inner_loop.env` is also merged into child env; for Loops inner-loop commands, runtime settings are read from run-scoped `inner_loop_runtime_config.json`.
 - PR approval is detected from GitHub review decision or from allowlisted approval comments configured in `task_provider_config`, after optional review-actor filtering from `task_provider_config.allowlist`.
 
 ### `loops clean`
@@ -266,10 +263,6 @@ Behavior summary:
 - If `run.json` is missing, task fields fall back to `LOOPS_TASK_*` env vars (or defaults).
 - Exact state-mapped prompt strings are documented in `DESIGN.md` under `### Prompt catalog`.
 
-Direct module entrypoint:
-
-- `python -m loops`
-
 ### `loops handoff`
 
 Seeds and launches a `WAITING_ON_REVIEW` run from an existing Codex session.
@@ -289,8 +282,8 @@ Options:
 
 Behavior summary:
 
-- Resolves session id from argument, then `CODEX_THREAD_ID`, then latest `~/.codex/history.jsonl` session.
-- Reads the matching Codex transcript under `~/.codex/sessions` or `~/.codex/archived_sessions`.
+- Resolves session id from argument, then `CODEX_THREAD_ID`, then latest `${CODEX_HOME:-~/.codex}/history.jsonl` session.
+- Reads the matching Codex transcript under `${CODEX_HOME:-~/.codex}/sessions` or `${CODEX_HOME:-~/.codex}/archived_sessions`.
 - Derives PR URL and tracking task URL from conversation content; if either cannot be determined, prompts for it interactively (or fails with guidance in non-interactive mode).
 - Maps tracking task URL against provider poll results when possible; otherwise falls back to synthesized task metadata.
 - Creates a new run with:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Subcommands:
 - `init`: initialize `.loops/` structure and default config.
 - `run`: run the outer loop runner.
 - `inner-loop`: run inner loop for one run directory.
+- `handoff`: seed a run from an existing Codex session and hand review-driving to Loops.
 - `doctor`: upgrade config schema/default keys in `config.json`.
 - `clean`: delete empty run directories and archive completed runs.
 
@@ -134,6 +135,7 @@ loops init
 loops doctor
 loops run --run-once
 loops inner-loop --run-dir .loops/jobs/2026-02-09-example-task-123
+loops handoff 019cab59-95c2-7923-9049-be455a2beb37
 loops clean --dry-run
 ```
 
@@ -267,6 +269,36 @@ Behavior summary:
 Direct module entrypoint:
 
 - `python -m loops`
+
+### `loops handoff`
+
+Seeds and launches a `WAITING_ON_REVIEW` run from an existing Codex session.
+
+Usage:
+
+```sh
+loops handoff [session-id]
+```
+
+Options:
+
+- `--config PATH`: Config file path. Default: `.loops/config.json`.
+- `--pr-url TEXT`: Optional PR URL override when transcript-based discovery is ambiguous or unavailable.
+- `--task-url TEXT`: Optional tracking task URL override when transcript-based discovery is ambiguous or unavailable.
+- `-h, --help`: Show help.
+
+Behavior summary:
+
+- Resolves session id from argument, then `CODEX_THREAD_ID`, then latest `~/.codex/history.jsonl` session.
+- Reads the matching Codex transcript under `~/.codex/sessions` or `~/.codex/archived_sessions`.
+- Derives PR URL and tracking task URL from conversation content; if either cannot be determined, prompts for it interactively (or fails with guidance in non-interactive mode).
+- Maps tracking task URL against provider poll results when possible; otherwise falls back to synthesized task metadata.
+- Creates a new run with:
+  - `codex_session.id` set to the handed-off session id,
+  - `pr.review_status="open"`,
+  - `pr.review_addressed_at=null` (treat all existing PR feedback/comments as unread),
+  - derived state `WAITING_ON_REVIEW`.
+- Launches inner loop using the configured launcher path (`inner_loop.command`) and runtime config behavior.
 
 ## Environment variables
 

--- a/docs/flows/ref.inner-loop.md
+++ b/docs/flows/ref.inner-loop.md
@@ -28,9 +28,9 @@ How does the inner loop execute a single run directory end-to-end, derive state 
 
 ## Entry points
 
-- CLI command `python -m loops inner-loop` resolves run directory and calls `run_inner_loop(...)` (`loops/core/cli.py`).
+- CLI command `loops inner-loop` resolves run directory and calls `run_inner_loop(...)` (`loops/core/cli.py`).
 - Outer-loop launched process invokes the same inner-loop command with `LOOPS_RUN_DIR`; run-scoped settings are loaded from `inner_loop_runtime_config.json` (`loops/core/outer_loop.py` + `loops/core/inner_loop.py`).
-- `python -m loops handoff [session-id]` seeds a new run in `WAITING_ON_REVIEW` from Codex conversation context (tracking task + PR) and then launches the configured inner-loop command.
+- `loops handoff [session-id]` seeds a new run in `WAITING_ON_REVIEW` from Codex conversation context (tracking task + PR) and then launches the configured inner-loop command.
 
 ## Call path
 

--- a/docs/flows/ref.inner-loop.md
+++ b/docs/flows/ref.inner-loop.md
@@ -1,6 +1,6 @@
 # Inner Loop Flow
 
-Last updated: 2026-03-03
+Last updated: 2026-03-05
 
 ## Overview
 
@@ -30,6 +30,7 @@ How does the inner loop execute a single run directory end-to-end, derive state 
 
 - CLI command `python -m loops inner-loop` resolves run directory and calls `run_inner_loop(...)` (`loops/core/cli.py`).
 - Outer-loop launched process invokes the same inner-loop command with `LOOPS_RUN_DIR`; run-scoped settings are loaded from `inner_loop_runtime_config.json` (`loops/core/outer_loop.py` + `loops/core/inner_loop.py`).
+- `python -m loops handoff [session-id]` seeds a new run in `WAITING_ON_REVIEW` from Codex conversation context (tracking task + PR) and then launches the configured inner-loop command.
 
 ## Call path
 
@@ -144,7 +145,7 @@ None identified.
 
 ### Entry assumptions and boundaries
 
-- Outer loop has created the run directory and initial `run.json` (`loops/core/outer_loop.py:293`).
+- Outer loop (or `loops handoff`) has created the run directory and initial `run.json`.
 - CLI or module entry resolves run dir and calls `run_inner_loop` (`loops/core/cli.py:90`, `loops/core/inner_loop.py:982`).
 - Inner loop owns future `run.json` mutations through `write_run_record` (`loops/state/run_record.py:206`).
 
@@ -345,6 +346,7 @@ A: Inner loop only.
 [keep this for the user to add notes. do not change between edits]
 
 ## Changelog
+- 2026-03-05: Added `loops handoff [session-id]` as an inner-loop entry path that seeds `WAITING_ON_REVIEW` runs from Codex conversation-derived PR/task context. (019cbc25-7679-72f2-9fa9-1a6dbf122fca)
 - 2026-03-03: Added deterministic state-hook lifecycle semantics (`on_enter`/`on_exit`), provider-backed task-status transitions, and hook-ledger (`state_hooks.json`) dedupe details. (019cb477-2e59-7311-add3-9b2f19720d5e)
 - 2026-03-02: Documented run-record checkout metadata (`checkout_mode`, `starting_commit`) and worktree setup instruction injection on initial RUNNING prompts. (019cabf2-f02b-7521-b814-5b0fcafe3d34)
 - 2026-03-02: Removed legacy `inner_loop_approval_config.json` fallback; comment-approval settings now load only from `inner_loop_runtime_config.json`. (019cabe9-52d6-73a2-b856-da28851da5b5)

--- a/loops/__main__.py
+++ b/loops/__main__.py
@@ -5,7 +5,7 @@ import sys
 from loops.core.cli import main
 
 
-_CLI_SUBCOMMANDS = {"init", "run", "inner-loop", "signal", "doctor", "clean"}
+_CLI_SUBCOMMANDS = {"init", "run", "inner-loop", "signal", "doctor", "clean", "handoff"}
 
 
 def _normalize_argv(argv: list[str]) -> list[str]:

--- a/loops/commands/handoff.py
+++ b/loops/commands/handoff.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import click
+
+
+@click.command("handoff")
+@click.argument("session_id", required=False)
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(".loops/config.json"),
+    show_default=True,
+    help="Path to the loops config JSON.",
+)
+@click.option(
+    "--pr-url",
+    "pr_url",
+    type=str,
+    default=None,
+    help="Optional PR URL override when session discovery is ambiguous.",
+)
+@click.option(
+    "--task-url",
+    "task_url",
+    type=str,
+    default=None,
+    help="Optional tracking task URL override when session discovery is ambiguous.",
+)
+def handoff_command(
+    session_id: Optional[str],
+    config_path: Path,
+    pr_url: Optional[str],
+    task_url: Optional[str],
+) -> None:
+    """Handoff an existing Codex session into a Loops WAITING_ON_REVIEW run."""
+
+    from loops.core import cli as cli_module
+
+    cli_module._run_handoff_command(
+        config_path=config_path,
+        session_id=session_id,
+        pr_url=pr_url,
+        task_url=task_url,
+    )

--- a/loops/core/cli.py
+++ b/loops/core/cli.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 """Top-level command-line interface for Loops."""
 
 from dataclasses import replace
+from datetime import datetime, timezone
 import json
 import os
+import re
 import shlex
+import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Mapping, Optional
 
 import click
 
@@ -21,20 +24,27 @@ from loops.core.outer_loop import (
     _resolve_provider_comment_approval_pattern,
     _resolve_provider_comment_approval_usernames,
     _resolve_provider_review_actor_usernames,
+    _select_task_by_url,
+    create_run_dir,
     build_default_loop_config_payload,
     build_inner_loop_launcher,
     build_provider,
     load_config,
+    read_outer_state,
+    _resolve_starting_commit,
     upgrade_config_payload,
     write_outer_state,
 )
 from loops.state.constants import (
+    AGENT_LOG_FILE_NAME,
     INNER_LOOP_RUNS_DIR_NAME,
     LATEST_LOOPS_CONFIG_VERSION,
     OUTER_LOG_FILE_NAME,
     OUTER_STATE_FILE_NAME,
+    RUN_LOG_FILE_NAME,
     RUN_RECORD_FILE_NAME,
 )
+from loops.state.run_record import CodexSession, RunPR, RunRecord, Task, write_run_record
 from loops.task_providers.github_projects_v2 import (
     GITHUB_PROJECTS_V2_PROVIDER_ID,
     build_default_provider_config_payload,
@@ -95,6 +105,391 @@ def _run_outer_loop(
         if isinstance(exc, SyncModeInterruptedError):
             _print_sync_resume_instructions(run_dir=exc.run_dir)
         raise click.Abort() from exc
+
+
+GITHUB_PR_URL_PATTERN = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+"
+)
+GITHUB_ISSUE_URL_PATTERN = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/[0-9]+"
+)
+GITHUB_REPO_URL_PATTERN = re.compile(
+    r"^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/(pull|issues)/[0-9]+$"
+)
+GITHUB_REMOTE_REPO_PATTERN = re.compile(
+    r"(?:github\.com[:/])([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?$"
+)
+
+
+def _run_handoff_command(
+    *,
+    config_path: Path,
+    session_id: Optional[str],
+    pr_url: Optional[str],
+    task_url: Optional[str],
+) -> None:
+    """Seed and launch a WAITING_ON_REVIEW run from an existing Codex session."""
+
+    resolved_session_id = _resolve_handoff_session_id(session_id)
+    transcript_path = _find_codex_session_transcript(resolved_session_id)
+
+    loops_config = load_config(config_path)
+    if loops_config.inner_loop is None:
+        loops_config = replace(
+            loops_config,
+            inner_loop=_build_default_inner_loop_config(),
+        )
+    provider = build_provider(loops_config)
+
+    repo_slug = _resolve_repo_slug(_resolve_loops_root(config_path).resolve().parent)
+    discovered_pr_url: Optional[str] = None
+    discovered_task_url: Optional[str] = None
+    pr_candidates: tuple[str, ...] = ()
+    task_candidates: tuple[str, ...] = ()
+    if transcript_path is not None:
+        (
+            discovered_pr_url,
+            discovered_task_url,
+            pr_candidates,
+            task_candidates,
+        ) = _derive_handoff_urls_from_session(
+            transcript_path,
+            repo_slug=repo_slug,
+        )
+
+    resolved_pr_url = _resolve_required_handoff_url(
+        label="PR",
+        provided=pr_url,
+        discovered=discovered_pr_url,
+        candidates=pr_candidates,
+    )
+    resolved_task_url = _resolve_required_handoff_url(
+        label="tracking task",
+        provided=task_url,
+        discovered=discovered_task_url,
+        candidates=task_candidates,
+    )
+
+    polled_tasks = provider.poll(limit=None)
+    try:
+        task = _select_task_by_url(polled_tasks, resolved_task_url)
+    except ValueError:
+        task = _build_synthesized_handoff_task(
+            resolved_task_url,
+            provider_id=loops_config.task_provider_id,
+        )
+
+    seeded_pr = _build_seed_handoff_pr(resolved_pr_url)
+    loops_root = _resolve_loops_root(config_path)
+    run_dir = create_run_dir(task, loops_root)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    run_record = RunRecord(
+        task=task,
+        pr=seeded_pr,
+        codex_session=CodexSession(id=resolved_session_id),
+        needs_user_input=False,
+        stream_logs_stdout=loops_config.loop_config.sync_mode,
+        checkout_mode=loops_config.loop_config.checkout_mode,
+        starting_commit=_resolve_starting_commit(loops_root),
+        last_state="WAITING_ON_REVIEW",
+        updated_at=now_iso,
+    )
+    write_run_record(
+        run_dir / RUN_RECORD_FILE_NAME,
+        run_record,
+        auto_approve_enabled=loops_config.loop_config.auto_approve_enabled,
+    )
+    (run_dir / RUN_LOG_FILE_NAME).touch(exist_ok=True)
+    (run_dir / AGENT_LOG_FILE_NAME).touch(exist_ok=True)
+
+    state_path = loops_root / OUTER_STATE_FILE_NAME
+    outer_state = read_outer_state(state_path)
+    outer_state.record_task(task, now_iso)
+    outer_state.initialized = True
+    outer_state.updated_at = now_iso
+    write_outer_state(state_path, outer_state)
+
+    launcher = build_inner_loop_launcher(
+        loops_config,
+        approval_comment_usernames=_resolve_provider_comment_approval_usernames(
+            provider
+        ),
+        approval_comment_pattern=_resolve_provider_comment_approval_pattern(provider),
+        review_actor_usernames=_resolve_provider_review_actor_usernames(provider),
+    )
+    launcher(run_dir, task)
+
+    click.echo(f"Handoff started in {run_dir}")
+    click.echo(f"Session: {resolved_session_id}")
+    click.echo(f"Task: {task.url}")
+    click.echo(f"PR: {seeded_pr.url}")
+
+
+def _resolve_handoff_session_id(session_id: Optional[str]) -> str:
+    if session_id is not None:
+        normalized = session_id.strip()
+        if normalized:
+            return normalized
+
+    env_session_id = os.environ.get("CODEX_THREAD_ID", "").strip()
+    if env_session_id:
+        return env_session_id
+
+    latest = _read_latest_session_id_from_history(
+        Path.home() / ".codex" / "history.jsonl"
+    )
+    if latest is not None:
+        return latest
+
+    if _is_interactive_stdin():
+        prompted = click.prompt("Codex session id", type=str).strip()
+        if prompted:
+            return prompted
+    raise click.ClickException(
+        "Unable to determine Codex session id. Pass `loops handoff <session-id>`."
+    )
+
+
+def _read_latest_session_id_from_history(history_path: Path) -> Optional[str]:
+    try:
+        lines = history_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for raw_line in reversed(lines):
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        session_id = payload.get("session_id")
+        if isinstance(session_id, str) and session_id.strip():
+            return session_id.strip()
+    return None
+
+
+def _find_codex_session_transcript(session_id: str) -> Optional[Path]:
+    codex_home = Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
+    roots = (
+        codex_home / "sessions",
+        codex_home / "archived_sessions",
+    )
+    candidates: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        pattern = f"*{session_id}.jsonl"
+        candidates.extend(root.rglob(pattern))
+    if not candidates:
+        return None
+    try:
+        return max(candidates, key=lambda path: path.stat().st_mtime)
+    except OSError:
+        return candidates[-1]
+
+
+def _derive_handoff_urls_from_session(
+    session_path: Path,
+    *,
+    repo_slug: Optional[str],
+) -> tuple[Optional[str], Optional[str], tuple[str, ...], tuple[str, ...]]:
+    pr_candidates: list[str] = []
+    task_candidates: list[str] = []
+    try:
+        lines = session_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None, None, (), ()
+
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if payload.get("type") == "session_meta":
+            continue
+        for text in _iter_json_strings(payload):
+            for match in GITHUB_PR_URL_PATTERN.finditer(text):
+                pr_candidates.append(match.group(0))
+            for match in GITHUB_ISSUE_URL_PATTERN.finditer(text):
+                task_candidates.append(match.group(0))
+
+    selected_pr, filtered_pr_candidates = _select_handoff_url_candidate(
+        pr_candidates,
+        repo_slug=repo_slug,
+    )
+    selected_task, filtered_task_candidates = _select_handoff_url_candidate(
+        task_candidates,
+        repo_slug=repo_slug,
+    )
+    return selected_pr, selected_task, filtered_pr_candidates, filtered_task_candidates
+
+
+def _iter_json_strings(value: object) -> Iterator[str]:
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, Mapping):
+        for nested in value.values():
+            yield from _iter_json_strings(nested)
+        return
+    if isinstance(value, list):
+        for nested in value:
+            yield from _iter_json_strings(nested)
+
+
+def _select_handoff_url_candidate(
+    candidates: list[str],
+    *,
+    repo_slug: Optional[str],
+) -> tuple[Optional[str], tuple[str, ...]]:
+    unique_candidates = _dedupe_preserve_order(candidates)
+    if not unique_candidates:
+        return None, ()
+    if repo_slug:
+        repo_matches = tuple(
+            candidate
+            for candidate in unique_candidates
+            if _repo_slug_from_github_url(candidate) == repo_slug
+        )
+        if len(repo_matches) == 1:
+            return repo_matches[0], repo_matches
+        if len(repo_matches) > 1:
+            return None, repo_matches
+    if len(unique_candidates) == 1:
+        return unique_candidates[0], unique_candidates
+    return None, unique_candidates
+
+
+def _dedupe_preserve_order(values: list[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return tuple(deduped)
+
+
+def _resolve_required_handoff_url(
+    *,
+    label: str,
+    provided: Optional[str],
+    discovered: Optional[str],
+    candidates: tuple[str, ...],
+) -> str:
+    normalized_provided = (provided or "").strip()
+    if normalized_provided:
+        return normalized_provided
+    if discovered:
+        return discovered
+
+    if _is_interactive_stdin():
+        if candidates:
+            click.echo(f"Could not determine {label} URL from session context.")
+            click.echo("Candidates:")
+            for candidate in candidates:
+                click.echo(f"- {candidate}")
+        prompted = click.prompt(f"Enter {label} URL", type=str).strip()
+        if prompted:
+            return prompted
+
+    candidate_hint = ""
+    if candidates:
+        candidate_hint = " Candidates: " + ", ".join(candidates[:5])
+    raise click.ClickException(
+        f"Unable to determine {label} URL from session and no override was provided."
+        f"{candidate_hint}"
+    )
+
+
+def _is_interactive_stdin() -> bool:
+    try:
+        return click.get_text_stream("stdin").isatty()
+    except Exception:
+        return False
+
+
+def _resolve_repo_slug(workspace_root: Path) -> Optional[str]:
+    try:
+        completed = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=workspace_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    remote_url = completed.stdout.strip()
+    if not remote_url:
+        return None
+    return _repo_slug_from_remote(remote_url)
+
+
+def _repo_slug_from_remote(remote_url: str) -> Optional[str]:
+    match = GITHUB_REMOTE_REPO_PATTERN.search(remote_url.strip())
+    if match is None:
+        return None
+    owner = match.group(1)
+    repo = match.group(2)
+    return f"{owner}/{repo}".casefold()
+
+
+def _repo_slug_from_github_url(url: str) -> Optional[str]:
+    match = GITHUB_REPO_URL_PATTERN.match(url.strip())
+    if match is None:
+        return None
+    return f"{match.group(1)}/{match.group(2)}".casefold()
+
+
+def _build_seed_handoff_pr(pr_url: str) -> RunPR:
+    normalized_url = pr_url.strip()
+    match = GITHUB_PR_URL_PATTERN.search(normalized_url)
+    if match is None:
+        raise click.ClickException(f"Invalid GitHub PR URL: {pr_url}")
+    canonical_url = match.group(0)
+    parts = canonical_url.split("/")
+    return RunPR(
+        url=canonical_url,
+        number=int(parts[-1]),
+        repo=f"{parts[3]}/{parts[4]}",
+        review_status="open",
+        ci_status=None,
+        ci_last_checked_at=None,
+        merged_at=None,
+        last_checked_at=None,
+        latest_review_submitted_at=None,
+        review_addressed_at=None,
+    )
+
+
+def _build_synthesized_handoff_task(task_url: str, *, provider_id: str) -> Task:
+    now_iso = datetime.now(timezone.utc).isoformat()
+    normalized_url = task_url.strip()
+    issue_match = GITHUB_ISSUE_URL_PATTERN.search(normalized_url)
+    if issue_match is not None:
+        canonical_url = issue_match.group(0)
+    else:
+        canonical_url = normalized_url
+    repo = _repo_slug_from_github_url(canonical_url)
+    task_id = canonical_url
+    if canonical_url.rstrip("/").split("/")[-1].isdigit():
+        task_id = canonical_url.rstrip("/").split("/")[-1]
+    return Task(
+        provider_id=provider_id,
+        id=task_id,
+        title=f"Handoff task {task_id}",
+        status="handoff",
+        url=canonical_url,
+        created_at=now_iso,
+        updated_at=now_iso,
+        repo=repo,
+    )
 
 
 def _run_inner_loop_command(
@@ -231,6 +626,7 @@ def _resolve_loops_root(config_path: Path) -> Path:
 # call helpers from this module.
 from loops.commands.clean import clean_command as clean_command
 from loops.commands.doctor import doctor_command as doctor_command
+from loops.commands.handoff import handoff_command as handoff_command
 from loops.commands.init import init_command as init_command
 from loops.commands.inner_loop import inner_loop_command as inner_loop_command
 from loops.commands.run import run_command as run_command
@@ -240,6 +636,7 @@ main.add_command(inner_loop_command)
 main.add_command(init_command)
 main.add_command(doctor_command)
 main.add_command(clean_command)
+main.add_command(handoff_command)
 
 
 if __name__ == "__main__":

--- a/loops/core/cli.py
+++ b/loops/core/cli.py
@@ -181,13 +181,20 @@ def _run_handoff_command(
         candidates=task_candidates,
     )
 
-    polled_tasks = provider.poll(limit=None)
+    task = _build_synthesized_handoff_task(
+        resolved_task_url,
+        provider_id=loops_config.task_provider_id,
+    )
     try:
+        polled_tasks = provider.poll(limit=None)
         task = _select_task_by_url(polled_tasks, resolved_task_url)
     except ValueError:
-        task = _build_synthesized_handoff_task(
-            resolved_task_url,
-            provider_id=loops_config.task_provider_id,
+        pass
+    except Exception as exc:
+        click.echo(
+            "[loops] provider poll unavailable during handoff; "
+            f"using synthesized task metadata ({type(exc).__name__}: {exc})",
+            err=True,
         )
 
     seeded_pr = _build_seed_handoff_pr(resolved_pr_url)
@@ -246,9 +253,8 @@ def _resolve_handoff_session_id(session_id: Optional[str]) -> str:
     if env_session_id:
         return env_session_id
 
-    latest = _read_latest_session_id_from_history(
-        Path.home() / ".codex" / "history.jsonl"
-    )
+    codex_home = _resolve_codex_home()
+    latest = _read_latest_session_id_from_history(codex_home / "history.jsonl")
     if latest is not None:
         return latest
 
@@ -281,7 +287,7 @@ def _read_latest_session_id_from_history(history_path: Path) -> Optional[str]:
 
 
 def _find_codex_session_transcript(session_id: str) -> Optional[Path]:
-    codex_home = Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
+    codex_home = _resolve_codex_home()
     roots = (
         codex_home / "sessions",
         codex_home / "archived_sessions",
@@ -298,6 +304,10 @@ def _find_codex_session_transcript(session_id: str) -> Optional[Path]:
         return max(candidates, key=lambda path: path.stat().st_mtime)
     except OSError:
         return candidates[-1]
+
+
+def _resolve_codex_home() -> Path:
+    return Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
 
 
 def _derive_handoff_urls_from_session(

--- a/loops/core/cli.py
+++ b/loops/core/cli.py
@@ -163,6 +163,17 @@ def _run_handoff_command(
         discovered=discovered_pr_url,
         candidates=pr_candidates,
     )
+    preferred_task_repo_slug = _repo_slug_from_github_url(resolved_pr_url) or repo_slug
+    if (
+        not (task_url or "").strip()
+        and discovered_task_url is None
+        and task_candidates
+    ):
+        discovered_task_url, task_candidates = _select_handoff_url_candidate(
+            list(task_candidates),
+            repo_slug=preferred_task_repo_slug,
+            strict_repo=True,
+        )
     resolved_task_url = _resolve_required_handoff_url(
         label="tracking task",
         provided=task_url,
@@ -309,9 +320,7 @@ def _derive_handoff_urls_from_session(
             payload = json.loads(stripped)
         except json.JSONDecodeError:
             continue
-        if payload.get("type") == "session_meta":
-            continue
-        for text in _iter_json_strings(payload):
+        for text in _iter_handoff_session_texts(payload):
             for match in GITHUB_PR_URL_PATTERN.finditer(text):
                 pr_candidates.append(match.group(0))
             for match in GITHUB_ISSUE_URL_PATTERN.finditer(text):
@@ -328,23 +337,37 @@ def _derive_handoff_urls_from_session(
     return selected_pr, selected_task, filtered_pr_candidates, filtered_task_candidates
 
 
-def _iter_json_strings(value: object) -> Iterator[str]:
-    if isinstance(value, str):
-        yield value
+def _iter_handoff_session_texts(payload: Mapping[str, object]) -> Iterator[str]:
+    if payload.get("type") != "response_item":
         return
-    if isinstance(value, Mapping):
-        for nested in value.values():
-            yield from _iter_json_strings(nested)
+    nested_payload = payload.get("payload")
+    if not isinstance(nested_payload, Mapping):
         return
-    if isinstance(value, list):
-        for nested in value:
-            yield from _iter_json_strings(nested)
+    if nested_payload.get("type") != "message":
+        return
+    if nested_payload.get("role") not in {"user", "assistant"}:
+        return
+    content = nested_payload.get("content")
+    if not isinstance(content, list):
+        return
+    for item in content:
+        if not isinstance(item, Mapping):
+            continue
+        item_type = item.get("type")
+        if item_type not in {"input_text", "output_text", "text"}:
+            continue
+        text = item.get("text")
+        if isinstance(text, str):
+            stripped = text.strip()
+            if stripped:
+                yield stripped
 
 
 def _select_handoff_url_candidate(
     candidates: list[str],
     *,
     repo_slug: Optional[str],
+    strict_repo: bool = False,
 ) -> tuple[Optional[str], tuple[str, ...]]:
     unique_candidates = _dedupe_preserve_order(candidates)
     if not unique_candidates:
@@ -359,6 +382,8 @@ def _select_handoff_url_candidate(
             return repo_matches[0], repo_matches
         if len(repo_matches) > 1:
             return None, repo_matches
+        if strict_repo:
+            return None, ()
     if len(unique_candidates) == 1:
         return unique_candidates[0], unique_candidates
     return None, unique_candidates

--- a/loops/core/cli.py
+++ b/loops/core/cli.py
@@ -513,12 +513,14 @@ def _build_synthesized_handoff_task(task_url: str, *, provider_id: str) -> Task:
         canonical_url = normalized_url
     repo = _repo_slug_from_github_url(canonical_url)
     task_id = canonical_url
-    if canonical_url.rstrip("/").split("/")[-1].isdigit():
-        task_id = canonical_url.rstrip("/").split("/")[-1]
+    title_suffix = task_id
+    trailing_token = canonical_url.rstrip("/").split("/")[-1]
+    if trailing_token.isdigit():
+        title_suffix = trailing_token
     return Task(
         provider_id=provider_id,
         id=task_id,
-        title=f"Handoff task {task_id}",
+        title=f"Handoff task {title_suffix}",
         status="handoff",
         url=canonical_url,
         created_at=now_iso,

--- a/loops/core/outer_loop.py
+++ b/loops/core/outer_loop.py
@@ -520,7 +520,56 @@ def upgrade_config_payload(payload: Any) -> tuple[dict[str, Any], bool]:
         if existing_provider_payload != provider_payload:
             upgraded["task_provider_config"] = provider_payload
 
+    existing_inner_loop_payload = upgraded.get("inner_loop")
+    if isinstance(existing_inner_loop_payload, dict):
+        inner_loop_payload = dict(existing_inner_loop_payload)
+        migrated_command, migrated_command_changed = _migrate_legacy_inner_loop_command(
+            inner_loop_payload.get("command")
+        )
+        if migrated_command_changed:
+            inner_loop_payload["command"] = migrated_command
+            changed = True
+        if existing_inner_loop_payload != inner_loop_payload:
+            upgraded["inner_loop"] = inner_loop_payload
+
     return upgraded, changed
+
+
+def _migrate_legacy_inner_loop_command(command: Any) -> tuple[Any, bool]:
+    if isinstance(command, str):
+        try:
+            parsed_command = shlex.split(command)
+        except ValueError:
+            return command, False
+        migrated_tokens, changed = _migrate_legacy_inner_loop_tokens(parsed_command)
+        if not changed:
+            return command, False
+        return shlex.join(migrated_tokens), True
+    if isinstance(command, list) and all(isinstance(item, str) for item in command):
+        return _migrate_legacy_inner_loop_tokens(list(command))
+    return command, False
+
+
+def _migrate_legacy_inner_loop_tokens(command: list[str]) -> tuple[list[str], bool]:
+    migrated = list(command)
+    changed = False
+    index = 0
+    while index + 1 < len(migrated):
+        if migrated[index] != "-m":
+            index += 1
+            continue
+        if migrated[index + 1].casefold() != "loops.inner_loop":
+            index += 1
+            continue
+        migrated[index + 1] = "loops"
+        changed = True
+        if (
+            index + 2 >= len(migrated)
+            or migrated[index + 2].casefold() != "inner-loop"
+        ):
+            migrated.insert(index + 2, "inner-loop")
+        index += 3
+    return migrated, changed
 
 
 def build_provider(
@@ -637,7 +686,7 @@ def build_inner_loop_launcher(
 
         if sync_mode:
             try:
-                subprocess.run(
+                completed = subprocess.run(
                     command,
                     cwd=inner_loop.working_dir,
                     env=env,
@@ -645,6 +694,12 @@ def build_inner_loop_launcher(
                 )
             except KeyboardInterrupt as exc:
                 raise SyncModeInterruptedError(run_dir=run_dir) from exc
+            if completed.returncode != 0:
+                rendered_command = shlex.join(command)
+                raise RuntimeError(
+                    "inner loop command failed "
+                    f"(exit={completed.returncode}): {rendered_command}"
+                )
             return
 
         log_fd = os.open(str(run_log), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
@@ -671,7 +726,10 @@ def _is_loops_inner_loop_command(command: list[str]) -> bool:
             if command[index + 1].casefold() == "inner-loop":
                 return True
         if item == "-m" and index + 1 < len(command):
-            if command[index + 1].casefold() == "loops" and index + 2 < len(command):
+            module_name = command[index + 1].casefold()
+            if module_name == "loops.inner_loop":
+                return True
+            if module_name == "loops" and index + 2 < len(command):
                 if command[index + 2].casefold() == "inner-loop":
                     return True
     return False

--- a/loops/core/outer_loop.py
+++ b/loops/core/outer_loop.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, Optional
 from urllib.parse import urlsplit, urlunsplit
 
+import click
 from pydantic import ValidationError
 
 from loops.state.approval_config import (
@@ -521,8 +522,18 @@ def upgrade_config_payload(payload: Any) -> tuple[dict[str, Any], bool]:
             upgraded["task_provider_config"] = provider_payload
 
     existing_inner_loop_payload = upgraded.get("inner_loop")
-    if isinstance(existing_inner_loop_payload, dict):
+    if isinstance(existing_inner_loop_payload, str):
+        inner_loop_payload = {"command": existing_inner_loop_payload}
+        upgraded["inner_loop"] = inner_loop_payload
+        changed = True
+    elif existing_inner_loop_payload is None:
+        inner_loop_payload = None
+    elif isinstance(existing_inner_loop_payload, dict):
         inner_loop_payload = dict(existing_inner_loop_payload)
+    else:
+        raise TypeError("inner_loop must be an object")
+
+    if isinstance(inner_loop_payload, dict):
         migrated_command, migrated_command_changed = _migrate_legacy_inner_loop_command(
             inner_loop_payload.get("command")
         )
@@ -696,7 +707,7 @@ def build_inner_loop_launcher(
                 raise SyncModeInterruptedError(run_dir=run_dir) from exc
             if completed.returncode != 0:
                 rendered_command = shlex.join(command)
-                raise RuntimeError(
+                raise click.ClickException(
                     "inner loop command failed "
                     f"(exit={completed.returncode}): {rendered_command}"
                 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1017,7 +1017,7 @@ def test_run_handoff_command_seeds_waiting_on_review_and_launches(
     monkeypatch.setattr(
         cli_module,
         "_derive_handoff_urls_from_session",
-        lambda _path, repo_slug=None: (
+        lambda _path, **_kwargs: (
             "https://github.com/acme/api/pull/88",
             "https://github.com/acme/api/issues/77",
             ("https://github.com/acme/api/pull/88",),
@@ -1059,6 +1059,115 @@ def test_run_handoff_command_seeds_waiting_on_review_and_launches(
     assert captured["approval_comment_usernames"] == ("maintainer",)
     assert captured["approval_comment_pattern"] == r"^\s*/shipit\b"
     assert captured["review_actor_usernames"] == ("reviewer",)
+
+
+def test_run_handoff_command_falls_back_when_provider_poll_fails(
+    tmp_path: Path,
+    monkeypatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    loops_root = tmp_path / ".loops"
+    loops_root.mkdir(parents=True)
+    config_path = loops_root / "config.json"
+    config_path.write_text("{}")
+    loaded = LoopsConfig(
+        version=LATEST_LOOPS_CONFIG_VERSION,
+        task_provider_id="github_projects_v2",
+        task_provider_config={
+            "url": "https://github.com/orgs/acme/projects/7",
+            "status_field": "Status",
+        },
+        loop_config=OuterLoopConfig(sync_mode=False),
+        inner_loop=None,
+    )
+
+    class ProviderStub:
+        approval_comment_usernames = ()
+        approval_comment_pattern = r"^\s*/approve\b"
+        review_actor_allowlist = ()
+
+        def poll(self, limit: int | None = None) -> list[Task]:
+            assert limit is None
+            raise RuntimeError("poll unavailable")
+
+    provider = ProviderStub()
+    captured: dict[str, object] = {}
+
+    def fake_build_inner_loop_launcher(
+        _config: LoopsConfig,
+        *,
+        approval_comment_usernames: tuple[str, ...] = (),
+        approval_comment_pattern: str = r"^\s*/approve\b",
+        review_actor_usernames: tuple[str, ...] = (),
+    ):
+        captured["approval_comment_usernames"] = approval_comment_usernames
+        captured["approval_comment_pattern"] = approval_comment_pattern
+        captured["review_actor_usernames"] = review_actor_usernames
+
+        def _launch(run_dir: Path, launch_task: Task) -> None:
+            captured["run_dir"] = run_dir
+            captured["launch_task"] = launch_task
+
+        return _launch
+
+    monkeypatch.setattr(cli_module, "load_config", lambda _path: loaded)
+    monkeypatch.setattr(cli_module, "build_provider", lambda _config: provider)
+    monkeypatch.setattr(cli_module, "build_inner_loop_launcher", fake_build_inner_loop_launcher)
+    monkeypatch.setattr(cli_module, "_resolve_starting_commit", lambda _root: "abc123")
+    monkeypatch.setattr(cli_module, "_find_codex_session_transcript", lambda _id: tmp_path / "session.jsonl")
+    monkeypatch.setattr(
+        cli_module,
+        "_derive_handoff_urls_from_session",
+        lambda _path, **_kwargs: (
+            "https://github.com/acme/api/pull/88",
+            "https://github.com/acme/api/issues/77",
+            ("https://github.com/acme/api/pull/88",),
+            ("https://github.com/acme/api/issues/77",),
+        ),
+    )
+
+    cli_module._run_handoff_command(
+        config_path=config_path,
+        session_id="session-fallback",
+        pr_url=None,
+        task_url=None,
+    )
+
+    captured_err = capsys.readouterr().err
+    assert "provider poll unavailable during handoff" in captured_err
+    run_dir = captured.get("run_dir")
+    assert isinstance(run_dir, Path)
+    run_record = read_run_record(run_dir / "run.json")
+    assert run_record.task.url == "https://github.com/acme/api/issues/77"
+    assert run_record.task.title == "Handoff task 77"
+    assert run_record.codex_session is not None
+    assert run_record.codex_session.id == "session-fallback"
+    assert run_record.last_state == "WAITING_ON_REVIEW"
+    assert captured["approval_comment_usernames"] == ()
+    assert captured["approval_comment_pattern"] == r"^\s*/approve\b"
+    assert captured["review_actor_usernames"] == ()
+
+
+def test_resolve_handoff_session_id_uses_codex_home_history(tmp_path: Path, monkeypatch) -> None:
+    codex_home = tmp_path / "custom-codex-home"
+    codex_home.mkdir(parents=True)
+    history_path = codex_home / "history.jsonl"
+    history_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"session_id": "older-session"}),
+                json.dumps({"session_id": "latest-session"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+
+    resolved = cli_module._resolve_handoff_session_id(None)
+
+    assert resolved == "latest-session"
 
 
 def test_derive_handoff_urls_from_session_ignores_tool_and_developer_content(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1138,6 +1138,7 @@ def test_run_handoff_command_falls_back_when_provider_poll_fails(
     run_dir = captured.get("run_dir")
     assert isinstance(run_dir, Path)
     run_record = read_run_record(run_dir / "run.json")
+    assert run_record.task.id == "https://github.com/acme/api/issues/77"
     assert run_record.task.url == "https://github.com/acme/api/issues/77"
     assert run_record.task.title == "Handoff task 77"
     assert run_record.codex_session is not None
@@ -1146,6 +1147,17 @@ def test_run_handoff_command_falls_back_when_provider_poll_fails(
     assert captured["approval_comment_usernames"] == ()
     assert captured["approval_comment_pattern"] == r"^\s*/approve\b"
     assert captured["review_actor_usernames"] == ()
+
+
+def test_build_synthesized_handoff_task_uses_canonical_url_as_id() -> None:
+    task = cli_module._build_synthesized_handoff_task(
+        "https://github.com/acme/api/issues/77/comments/1",
+        provider_id="github_projects_v2",
+    )
+
+    assert task.id == "https://github.com/acme/api/issues/77"
+    assert task.url == "https://github.com/acme/api/issues/77"
+    assert task.title == "Handoff task 77"
 
 
 def test_resolve_handoff_session_id_uses_codex_home_history(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1061,6 +1061,89 @@ def test_run_handoff_command_seeds_waiting_on_review_and_launches(
     assert captured["review_actor_usernames"] == ("reviewer",)
 
 
+def test_derive_handoff_urls_from_session_ignores_tool_and_developer_content(
+    tmp_path: Path,
+) -> None:
+    session_path = tmp_path / "session.jsonl"
+    session_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "session_meta", "payload": {}}),
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "function_call_output",
+                            "output": (
+                                "irrelevant https://github.com/acme/api/pull/9 "
+                                "https://github.com/acme/api/issues/9"
+                            ),
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "developer",
+                            "content": [
+                                {
+                                    "type": "input_text",
+                                    "text": "ignore https://github.com/acme/api/issues/77",
+                                }
+                            ],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": "Opened https://github.com/kevinslin/loops/pull/80",
+                                }
+                            ],
+                        },
+                    }
+                ),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    discovered_pr, discovered_task, pr_candidates, task_candidates = (
+        cli_module._derive_handoff_urls_from_session(
+            session_path,
+            repo_slug="kevinslin/loops",
+        )
+    )
+
+    assert discovered_pr == "https://github.com/kevinslin/loops/pull/80"
+    assert discovered_task is None
+    assert pr_candidates == ("https://github.com/kevinslin/loops/pull/80",)
+    assert task_candidates == ()
+
+
+def test_select_handoff_url_candidate_strict_repo_filters_cross_repo_candidates() -> None:
+    selected, candidates = cli_module._select_handoff_url_candidate(
+        [
+            "https://github.com/acme/api/issues/9",
+            "https://github.com/acme/api/issues/42",
+        ],
+        repo_slug="kevinslin/loops",
+        strict_repo=True,
+    )
+
+    assert selected is None
+    assert candidates == ()
+
+
 def test_run_outer_loop_task_url_implies_run_once_and_force(
     tmp_path: Path,
     monkeypatch,
@@ -1343,6 +1426,35 @@ def test_doctor_moves_legacy_loop_approval_keys_to_provider_config(
     assert payload["task_provider_config"]["approval_comment_pattern"] == r"^\s*/shipit\b"
     assert "approval_comment_usernames" not in payload["loop_config"]
     assert "approval_comment_pattern" not in payload["loop_config"]
+
+
+def test_doctor_migrates_legacy_inner_loop_module_command(tmp_path: Path) -> None:
+    runner = CliRunner()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": LATEST_LOOPS_CONFIG_VERSION,
+                "task_provider_id": "github_projects_v2",
+                "task_provider_config": {"url": "https://github.com/orgs/acme/projects/7"},
+                "inner_loop": {
+                    "command": ["python3", "-m", "loops.inner_loop"],
+                    "append_task_url": False,
+                },
+            }
+        )
+    )
+
+    result = runner.invoke(main, ["doctor", "--config", str(config_path)])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(config_path.read_text())
+    assert payload["inner_loop"]["command"] == [
+        "python3",
+        "-m",
+        "loops",
+        "inner-loop",
+    ]
 
 
 def test_doctor_upgrades_versionless_legacy_config(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -447,6 +447,8 @@ def test_normalize_argv_preserves_known_subcommands() -> None:
     assert _normalize_argv(argv) == argv
     clean_argv = ["python", "clean"]
     assert _normalize_argv(clean_argv) == clean_argv
+    handoff_argv = ["python", "handoff", "session-1"]
+    assert _normalize_argv(handoff_argv) == handoff_argv
 
 
 def test_normalize_argv_preserves_removed_signal_subcommand() -> None:
@@ -895,6 +897,168 @@ def test_run_command_passes_task_url_to_outer_loop(tmp_path: Path, monkeypatch) 
     assert captured["limit"] == 3
     assert captured["force"] is None
     assert captured["task_url"] == "https://github.com/acme/api/issues/42"
+
+
+def test_handoff_command_passes_arguments_to_core_handler(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runner = CliRunner()
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}")
+    captured: dict[str, object] = {}
+
+    def fake_run_handoff_command(
+        *,
+        config_path: Path,
+        session_id: str | None,
+        pr_url: str | None,
+        task_url: str | None,
+    ) -> None:
+        captured["config_path"] = config_path
+        captured["session_id"] = session_id
+        captured["pr_url"] = pr_url
+        captured["task_url"] = task_url
+
+    monkeypatch.setattr(cli_module, "_run_handoff_command", fake_run_handoff_command)
+
+    result = runner.invoke(
+        main,
+        [
+            "handoff",
+            "session-1",
+            "--config",
+            str(config_path),
+            "--pr-url",
+            "https://github.com/acme/api/pull/44",
+            "--task-url",
+            "https://github.com/acme/api/issues/44",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["config_path"] == config_path
+    assert captured["session_id"] == "session-1"
+    assert captured["pr_url"] == "https://github.com/acme/api/pull/44"
+    assert captured["task_url"] == "https://github.com/acme/api/issues/44"
+
+
+def test_run_handoff_command_seeds_waiting_on_review_and_launches(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    loops_root = tmp_path / ".loops"
+    loops_root.mkdir(parents=True)
+    config_path = loops_root / "config.json"
+    config_path.write_text("{}")
+
+    task = Task(
+        provider_id="github_projects_v2",
+        id="issue-node-77",
+        title="Handoff issue",
+        status="Ready",
+        url="https://github.com/acme/api/issues/77",
+        created_at="2026-03-01T00:00:00Z",
+        updated_at="2026-03-01T00:00:00Z",
+        repo="acme/api",
+    )
+    loaded = LoopsConfig(
+        version=LATEST_LOOPS_CONFIG_VERSION,
+        task_provider_id="github_projects_v2",
+        task_provider_config={
+            "url": "https://github.com/orgs/acme/projects/7",
+            "status_field": "Status",
+        },
+        loop_config=OuterLoopConfig(
+            sync_mode=False,
+            checkout_mode="worktree",
+        ),
+        inner_loop=None,
+    )
+
+    class ProviderStub:
+        approval_comment_usernames = ("maintainer", "maintainer")
+        approval_comment_pattern = r"^\s*/shipit\b"
+        review_actor_allowlist = ("reviewer", "reviewer")
+
+        def poll(self, limit: int | None = None) -> list[Task]:
+            assert limit is None
+            return [task]
+
+    provider = ProviderStub()
+    captured: dict[str, object] = {}
+
+    def fake_build_inner_loop_launcher(
+        config: LoopsConfig,
+        *,
+        approval_comment_usernames: tuple[str, ...] = (),
+        approval_comment_pattern: str = r"^\s*/approve\b",
+        review_actor_usernames: tuple[str, ...] = (),
+    ):
+        captured["launcher_config"] = config
+        captured["approval_comment_usernames"] = approval_comment_usernames
+        captured["approval_comment_pattern"] = approval_comment_pattern
+        captured["review_actor_usernames"] = review_actor_usernames
+
+        def _launch(run_dir: Path, launch_task: Task) -> None:
+            captured["run_dir"] = run_dir
+            captured["launch_task"] = launch_task
+
+        return _launch
+
+    monkeypatch.setattr(cli_module, "load_config", lambda _path: loaded)
+    monkeypatch.setattr(cli_module, "build_provider", lambda _config: provider)
+    monkeypatch.setattr(cli_module, "build_inner_loop_launcher", fake_build_inner_loop_launcher)
+    monkeypatch.setattr(
+        cli_module,
+        "_find_codex_session_transcript",
+        lambda _session_id: tmp_path / "session.jsonl",
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "_derive_handoff_urls_from_session",
+        lambda _path, repo_slug=None: (
+            "https://github.com/acme/api/pull/88",
+            "https://github.com/acme/api/issues/77",
+            ("https://github.com/acme/api/pull/88",),
+            ("https://github.com/acme/api/issues/77",),
+        ),
+    )
+    monkeypatch.setattr(cli_module, "_resolve_starting_commit", lambda _root: "abc123")
+
+    cli_module._run_handoff_command(
+        config_path=config_path,
+        session_id="session-xyz",
+        pr_url=None,
+        task_url=None,
+    )
+
+    run_dir = captured.get("run_dir")
+    assert isinstance(run_dir, Path)
+    run_record = read_run_record(run_dir / "run.json")
+    assert run_record.task.url == "https://github.com/acme/api/issues/77"
+    assert run_record.pr is not None
+    assert run_record.pr.url == "https://github.com/acme/api/pull/88"
+    assert run_record.pr.review_status == "open"
+    assert run_record.pr.review_addressed_at is None
+    assert run_record.codex_session is not None
+    assert run_record.codex_session.id == "session-xyz"
+    assert run_record.needs_user_input is False
+    assert run_record.last_state == "WAITING_ON_REVIEW"
+    assert run_record.checkout_mode == "worktree"
+    assert run_record.starting_commit == "abc123"
+    assert (run_dir / "run.log").exists()
+    assert (run_dir / "agent.log").exists()
+
+    outer_state_payload = json.loads((loops_root / "outer_state.json").read_text())
+    task_entries = list((outer_state_payload.get("tasks") or {}).values())
+    assert len(task_entries) == 1
+    assert task_entries[0]["task"]["url"] == "https://github.com/acme/api/issues/77"
+    assert outer_state_payload["initialized"] is True
+    assert captured["launch_task"] == task
+    assert captured["approval_comment_usernames"] == ("maintainer",)
+    assert captured["approval_comment_pattern"] == r"^\s*/shipit\b"
+    assert captured["review_actor_usernames"] == ("reviewer",)
 
 
 def test_run_outer_loop_task_url_implies_run_once_and_force(

--- a/tests/test_outer_loop.py
+++ b/tests/test_outer_loop.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import click
 import pytest
 
 from loops.state.approval_config import (
@@ -382,6 +383,20 @@ def test_load_config_reads_sync_mode(tmp_path: Path) -> None:
     config = load_config(config_path)
     assert config.loop_config.sync_mode is True
     assert config.version == LATEST_LOOPS_CONFIG_VERSION
+
+
+def test_load_config_migrates_legacy_inner_loop_string_payload(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    payload = {
+        "task_provider_id": "github_projects_v2",
+        "task_provider_config": {},
+        "inner_loop": "echo hello",
+    }
+    config_path.write_text(json.dumps(payload))
+
+    config = load_config(config_path)
+    assert config.inner_loop is not None
+    assert config.inner_loop.command == ["echo", "hello"]
 
 
 def test_load_config_migrates_legacy_inner_loop_module_command(tmp_path: Path) -> None:
@@ -834,7 +849,7 @@ def test_build_inner_loop_launcher_sync_mode_interrupt_raises_typed_error(
     assert exc_info.value.run_dir == run_dir
 
 
-def test_build_inner_loop_launcher_sync_mode_raises_on_non_zero_exit(
+def test_build_inner_loop_launcher_sync_mode_raises_click_exception_on_non_zero_exit(
     tmp_path: Path, monkeypatch
 ) -> None:
     run_dir = tmp_path / "run"
@@ -859,7 +874,7 @@ def test_build_inner_loop_launcher_sync_mode_raises_on_non_zero_exit(
 
     monkeypatch.setattr("loops.core.outer_loop.subprocess.run", fake_run)
 
-    with pytest.raises(RuntimeError, match=r"inner loop command failed \(exit=2\)"):
+    with pytest.raises(click.ClickException, match=r"inner loop command failed \(exit=2\)"):
         launcher(run_dir, task)
 
 

--- a/tests/test_outer_loop.py
+++ b/tests/test_outer_loop.py
@@ -79,6 +79,7 @@ def list_run_dirs(loops_root: Path) -> list[Path]:
         (["uv", "run", "loops", "inner-loop"], True),
         ([sys.executable, "-m", "loops", "inner-loop"], True),
         (["uv", "run", sys.executable, "-X", "dev", "-m", "loops", "inner-loop"], True),
+        ([sys.executable, "-m", "loops.inner_loop"], True),
         (["python", "-m", "loops.other"], False),
         (["echo", "hello"], False),
     ],
@@ -381,6 +382,23 @@ def test_load_config_reads_sync_mode(tmp_path: Path) -> None:
     config = load_config(config_path)
     assert config.loop_config.sync_mode is True
     assert config.version == LATEST_LOOPS_CONFIG_VERSION
+
+
+def test_load_config_migrates_legacy_inner_loop_module_command(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    payload = {
+        "task_provider_id": "github_projects_v2",
+        "task_provider_config": {},
+        "inner_loop": {
+            "command": [sys.executable, "-m", "loops.inner_loop"],
+            "append_task_url": False,
+        },
+    }
+    config_path.write_text(json.dumps(payload))
+
+    config = load_config(config_path)
+    assert config.inner_loop is not None
+    assert config.inner_loop.command == [sys.executable, "-m", "loops", "inner-loop"]
 
 
 def test_load_config_reads_auto_approve_enabled(tmp_path: Path) -> None:
@@ -814,6 +832,35 @@ def test_build_inner_loop_launcher_sync_mode_interrupt_raises_typed_error(
         launcher(run_dir, task)
 
     assert exc_info.value.run_dir == run_dir
+
+
+def test_build_inner_loop_launcher_sync_mode_raises_on_non_zero_exit(
+    tmp_path: Path, monkeypatch
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    task = make_task("1", "Ship it")
+
+    config = LoopsConfig(
+        version=LATEST_LOOPS_CONFIG_VERSION,
+        task_provider_id="github_projects_v2",
+        task_provider_config={"url": "https://github.com/orgs/acme/projects/1"},
+        loop_config=OuterLoopConfig(sync_mode=True),
+        inner_loop=InnerLoopCommandConfig(
+            command=["echo", "hello"],
+            append_task_url=False,
+        ),
+    )
+    launcher = build_inner_loop_launcher(config)
+
+    def fake_run(command, *, cwd, env, check):
+        del cwd, env, check
+        return subprocess.CompletedProcess(command, 2)
+
+    monkeypatch.setattr("loops.core.outer_loop.subprocess.run", fake_run)
+
+    with pytest.raises(RuntimeError, match=r"inner loop command failed \(exit=2\)"):
+        launcher(run_dir, task)
 
 
 def test_build_inner_loop_launcher_writes_runtime_env_to_run_config(


### PR DESCRIPTION
fix: harden handoff URL detection and launcher behavior

## Context
- Branch: `codex/replace-dev-do-state-hooks`
- Base branch: `main`
- Changes:
  - feat: add handoff subcommand for loops takeover
  - fix: harden handoff URL detection and launcher behavior

## Testing
- [ ] Describe automated and manual tests run for this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "loops handoff [session-id]" command to seed a WAITING_ON_REVIEW run from a Codex session and launch the inner-loop flow.

* **Behavior Changes**
  * CLI now prefers the top-level "loops" entrypoint; inner-loop invocation normalized to "loops inner-loop".
  * Handoff seeds PR/task info from conversation context and initializes prior feedback as unread.
  * Synchronous inner-loop failures now surface as errors.

* **Documentation**
  * README and docs updated with handoff usage, options, and examples.

* **Tests**
  * Added extensive tests for handoff flows, URL selection, migration, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->